### PR TITLE
新機能: client_secretローテーションエンドポイントを追加

### DIFF
--- a/packages/shared/src/db/services.ts
+++ b/packages/shared/src/db/services.ts
@@ -81,3 +81,18 @@ export async function countServices(db: D1Database): Promise<number> {
     .first<{ count: number }>();
   return result?.count ?? 0;
 }
+
+export async function rotateClientSecret(
+  db: D1Database,
+  id: string,
+  newClientSecretHash: string
+): Promise<Service | null> {
+  return db
+    .prepare(
+      `UPDATE services SET client_secret_hash = ?, updated_at = datetime('now')
+       WHERE id = ?
+       RETURNING *`
+    )
+    .bind(newClientSecretHash, id)
+    .first<Service>();
+}

--- a/workers/admin/src/routes/services.test.ts
+++ b/workers/admin/src/routes/services.test.ts
@@ -343,6 +343,54 @@ describe('admin BFF — /api/services', () => {
     });
   });
 
+  describe('POST /:id/rotate-secret — client_secret再発行', () => {
+    it('セッションなしで401を返す', async () => {
+      const idpFetch = vi.fn();
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/services/service-1/rotate-secret', {
+        method: 'POST',
+      });
+      expect(res.status).toBe(401);
+      expect(idpFetch).not.toHaveBeenCalled();
+    });
+
+    it('管理者セッションでIdPにPOSTして新しいsecretを返す', async () => {
+      const rotated = {
+        id: 'service-1',
+        client_id: 'client-abc',
+        client_secret: 'new-secret-xyz',
+        updated_at: '2024-06-01T00:00:00Z',
+      };
+      const idpFetch = mockIdp(200, { data: rotated });
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/services/service-1/rotate-secret', {
+        method: 'POST',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json<{ data: typeof rotated }>();
+      expect(body.data.client_secret).toBe('new-secret-xyz');
+
+      const [calledReq] = (idpFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [Request];
+      expect(calledReq.method).toBe('POST');
+      expect(calledReq.url).toBe('https://id.0g0.xyz/api/services/service-1/rotate-secret');
+    });
+
+    it('IdPが404を返した場合はそのまま伝播する', async () => {
+      const idpFetch = mockIdp(404, { error: { code: 'NOT_FOUND' } });
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/services/no-such/rotate-secret', {
+        method: 'POST',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
   describe('DELETE /:id/redirect-uris/:uriId — リダイレクトURI削除', () => {
     it('セッションなしで401を返す', async () => {
       const idpFetch = vi.fn();

--- a/workers/admin/src/routes/services.ts
+++ b/workers/admin/src/routes/services.ts
@@ -77,6 +77,20 @@ app.delete('/:id', async (c) => {
   return proxyResponse(res);
 });
 
+// POST /api/services/:id/rotate-secret — client_secretの再発行
+app.post('/:id/rotate-secret', async (c) => {
+  const res = await fetchWithAuth(
+    c,
+    SESSION_COOKIE,
+    `${c.env.IDP_ORIGIN}/api/services/${c.req.param('id')}/rotate-secret`,
+    {
+      method: 'POST',
+      headers: { Origin: c.env.IDP_ORIGIN },
+    }
+  );
+  return proxyResponse(res);
+});
+
 // GET /api/services/:id/redirect-uris
 app.get('/:id/redirect-uris', async (c) => {
   const res = await fetchWithAuth(

--- a/workers/id/src/routes/docs.ts
+++ b/workers/id/src/routes/docs.ts
@@ -333,9 +333,10 @@ const INTERNAL_OPENAPI = {
           { name: 'serviceId', in: 'path', required: true, schema: { type: 'string' } },
         ],
         responses: {
-          '200': { description: '連携解除成功' },
+          '204': { description: '連携解除成功' },
           '401': { description: 'UNAUTHORIZED' },
-          '403': { description: 'FORBIDDEN' },
+          '403': { description: 'FORBIDDEN — オリジン不正' },
+          '404': { description: 'NOT_FOUND — 連携未存在' },
         },
       },
     },
@@ -431,6 +432,45 @@ const INTERNAL_OPENAPI = {
       },
     },
     '/api/users/{id}': {
+      get: {
+        tags: ['ユーザー API (管理者)'],
+        summary: 'ユーザー詳細取得',
+        description: '指定ユーザーの詳細情報を返す（管理者専用）。phone / address など内部フィールドも含む。',
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+        ],
+        responses: {
+          '200': {
+            description: 'ユーザー詳細',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    data: {
+                      allOf: [
+                        { $ref: '#/components/schemas/User' },
+                        {
+                          type: 'object',
+                          properties: {
+                            phone: { type: 'string', nullable: true },
+                            address: { type: 'string', nullable: true },
+                            updated_at: { type: 'string', format: 'date-time' },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '401': { description: 'UNAUTHORIZED' },
+          '403': { description: 'FORBIDDEN — 管理者権限なし' },
+          '404': { description: 'NOT_FOUND — ユーザー未存在' },
+        },
+      },
       delete: {
         tags: ['ユーザー API (管理者)'],
         summary: 'ユーザー削除',
@@ -514,16 +554,129 @@ const INTERNAL_OPENAPI = {
       },
     },
     '/api/services/{id}': {
-      delete: {
+      get: {
         tags: ['サービス管理 API (管理者)'],
-        summary: 'サービス削除',
+        summary: 'サービス取得',
+        description: '指定IDのサービス詳細を返す（管理者専用）。',
         security: [{ BearerAuth: [] }],
         parameters: [
           { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
         ],
         responses: {
-          '200': { description: '削除成功' },
-          '404': { description: 'NOT_FOUND' },
+          '200': {
+            description: 'サービス詳細',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { data: { $ref: '#/components/schemas/Service' } },
+                },
+              },
+            },
+          },
+          '401': { description: 'UNAUTHORIZED' },
+          '403': { description: 'FORBIDDEN — 管理者権限なし' },
+          '404': { description: 'NOT_FOUND — サービス未存在' },
+        },
+      },
+      patch: {
+        tags: ['サービス管理 API (管理者)'],
+        summary: 'サービス スコープ更新',
+        description: '指定サービスの許可スコープを更新する（管理者専用）。Origin/RefererヘッダーによるCSRF検証あり。',
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  allowed_scopes: {
+                    type: 'array',
+                    items: { type: 'string', enum: ['profile', 'email', 'phone', 'address'] },
+                    description: '新しい許可スコープ（空配列不可）',
+                  },
+                },
+                required: ['allowed_scopes'],
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: '更新成功',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { data: { $ref: '#/components/schemas/Service' } },
+                },
+              },
+            },
+          },
+          '400': { description: 'BAD_REQUEST — 不正なスコープ値または空配列' },
+          '401': { description: 'UNAUTHORIZED' },
+          '403': { description: 'FORBIDDEN — 管理者権限なし、またはオリジン不正' },
+          '404': { description: 'NOT_FOUND — サービス未存在' },
+        },
+      },
+      delete: {
+        tags: ['サービス管理 API (管理者)'],
+        summary: 'サービス削除',
+        description: '指定サービスを削除する（管理者専用）。Origin/RefererヘッダーによるCSRF検証あり。',
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+        ],
+        responses: {
+          '204': { description: '削除成功' },
+          '401': { description: 'UNAUTHORIZED' },
+          '403': { description: 'FORBIDDEN — 管理者権限なし、またはオリジン不正' },
+          '404': { description: 'NOT_FOUND — サービス未存在' },
+        },
+      },
+    },
+    '/api/services/{id}/rotate-secret': {
+      post: {
+        tags: ['サービス管理 API (管理者)'],
+        summary: 'クライアントシークレット再発行',
+        description:
+          '指定サービスのクライアントシークレットを再発行する（管理者専用）。' +
+          '旧シークレットは即時無効化される。新しい `client_secret` はこのレスポンスのみで返却（再取得不可）。' +
+          'Origin/RefererヘッダーによるCSRF検証あり。',
+        security: [{ BearerAuth: [] }],
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+        ],
+        responses: {
+          '200': {
+            description: '再発行成功（新しいclient_secretを含む）',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    data: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        client_id: { type: 'string' },
+                        client_secret: { type: 'string', description: '新しいクライアントシークレット（このレスポンスのみ）' },
+                        updated_at: { type: 'string', format: 'date-time' },
+                      },
+                      required: ['id', 'client_id', 'client_secret', 'updated_at'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+          '401': { description: 'UNAUTHORIZED' },
+          '403': { description: 'FORBIDDEN — 管理者権限なし、またはオリジン不正' },
+          '404': { description: 'NOT_FOUND — サービス未存在' },
         },
       },
     },
@@ -569,13 +722,17 @@ const INTERNAL_OPENAPI = {
       delete: {
         tags: ['サービス管理 API (管理者)'],
         summary: 'リダイレクトURI削除',
+        description: '指定リダイレクトURIを削除する（管理者専用）。Origin/RefererヘッダーによるCSRF検証あり。',
         security: [{ BearerAuth: [] }],
         parameters: [
           { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
           { name: 'uriId', in: 'path', required: true, schema: { type: 'string' } },
         ],
         responses: {
-          '200': { description: '削除成功' },
+          '204': { description: '削除成功' },
+          '401': { description: 'UNAUTHORIZED' },
+          '403': { description: 'FORBIDDEN — 管理者権限なし、またはオリジン不正' },
+          '404': { description: 'NOT_FOUND — サービス未存在' },
         },
       },
     },

--- a/workers/id/src/routes/services.test.ts
+++ b/workers/id/src/routes/services.test.ts
@@ -15,6 +15,7 @@ vi.mock('@0g0-id/shared', () => ({
   generateClientSecret: vi.fn(),
   sha256: vi.fn(),
   normalizeRedirectUri: vi.fn(),
+  rotateClientSecret: vi.fn(),
   verifyAccessToken: vi.fn(),
 }));
 
@@ -31,6 +32,7 @@ import {
   generateClientSecret,
   sha256,
   normalizeRedirectUri,
+  rotateClientSecret,
   verifyAccessToken,
 } from '@0g0-id/shared';
 
@@ -568,6 +570,84 @@ describe('POST /api/services/:id/redirect-uris', () => {
     expect(res.status).toBe(409);
     const body = await res.json<{ error: { code: string } }>();
     expect(body.error.code).toBe('CONFLICT');
+  });
+});
+
+// ===== POST /api/services/:id/rotate-secret（管理者のみ）=====
+describe('POST /api/services/:id/rotate-secret', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyAccessToken).mockResolvedValue(mockAdminPayload);
+    vi.mocked(findServiceById).mockResolvedValue(mockService);
+    vi.mocked(generateClientSecret).mockReturnValue('new-client-secret');
+    vi.mocked(sha256).mockResolvedValue('new-secret-hash');
+    vi.mocked(rotateClientSecret).mockResolvedValue({
+      ...mockService,
+      client_secret_hash: 'new-secret-hash',
+      updated_at: '2024-06-01T00:00:00Z',
+    });
+  });
+
+  it('認証なし → 401を返す', async () => {
+    const res = await sendRequest(app, '/api/services/service-1/rotate-secret', {
+      method: 'POST',
+      withAuth: false,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('管理者でない場合 → 403を返す', async () => {
+    vi.mocked(verifyAccessToken).mockResolvedValue(mockUserPayload);
+    const res = await sendRequest(app, '/api/services/service-1/rotate-secret', {
+      method: 'POST',
+      origin: 'https://admin.0g0.xyz',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('Originヘッダーなし（CSRF）→ 403を返す', async () => {
+    const res = await sendRequest(app, '/api/services/service-1/rotate-secret', {
+      method: 'POST',
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('新しいclient_secretを発行して返す', async () => {
+    const res = await sendRequest(app, '/api/services/service-1/rotate-secret', {
+      method: 'POST',
+      origin: 'https://admin.0g0.xyz',
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<{ data: Record<string, unknown> }>();
+    expect(body.data.id).toBe('service-1');
+    expect(body.data.client_id).toBe('client-abc');
+    expect(body.data.client_secret).toBe('new-client-secret');
+    expect(body.data).not.toHaveProperty('client_secret_hash');
+  });
+
+  it('rotateClientSecretが新しいハッシュで呼ばれる', async () => {
+    await sendRequest(app, '/api/services/service-1/rotate-secret', {
+      method: 'POST',
+      origin: 'https://admin.0g0.xyz',
+    });
+    expect(vi.mocked(rotateClientSecret)).toHaveBeenCalledWith(
+      expect.anything(),
+      'service-1',
+      'new-secret-hash'
+    );
+  });
+
+  it('サービスが存在しない場合（findServiceById）→ 404を返す', async () => {
+    vi.mocked(findServiceById).mockResolvedValue(null);
+    const res = await sendRequest(app, '/api/services/no-such/rotate-secret', {
+      method: 'POST',
+      origin: 'https://admin.0g0.xyz',
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe('NOT_FOUND');
   });
 });
 

--- a/workers/id/src/routes/services.ts
+++ b/workers/id/src/routes/services.ts
@@ -13,6 +13,7 @@ import {
   generateClientSecret,
   sha256,
   normalizeRedirectUri,
+  rotateClientSecret,
 } from '@0g0-id/shared';
 import type { IdpEnv, TokenPayload } from '@0g0-id/shared';
 import { authMiddleware } from '../middleware/auth';
@@ -239,6 +240,32 @@ app.post('/:id/redirect-uris', authMiddleware, adminMiddleware, csrfMiddleware, 
   } catch {
     return c.json({ error: { code: 'CONFLICT', message: 'Redirect URI already exists' } }, 409);
   }
+});
+
+// POST /api/services/:id/rotate-secret — client_secretの再発行
+app.post('/:id/rotate-secret', authMiddleware, adminMiddleware, csrfMiddleware, async (c) => {
+  const serviceId = c.req.param('id');
+  const service = await findServiceById(c.env.DB, serviceId);
+  if (!service) {
+    return c.json({ error: { code: 'NOT_FOUND', message: 'Service not found' } }, 404);
+  }
+
+  const newClientSecret = generateClientSecret();
+  const newClientSecretHash = await sha256(newClientSecret);
+
+  const updated = await rotateClientSecret(c.env.DB, serviceId, newClientSecretHash);
+  if (!updated) {
+    return c.json({ error: { code: 'NOT_FOUND', message: 'Service not found' } }, 404);
+  }
+
+  return c.json({
+    data: {
+      id: updated.id,
+      client_id: updated.client_id,
+      client_secret: newClientSecret,
+      updated_at: updated.updated_at,
+    },
+  });
 });
 
 // DELETE /api/services/:id/redirect-uris/:uriId


### PR DESCRIPTION
## Summary

- `POST /api/services/:id/rotate-secret` エンドポイントを新規追加
- client_secretが漏洩・失効した際に新しいシークレットを安全に再発行できる
- 管理者権限＋CSRF保護付き（既存のセキュリティポリシーと統一）

## 変更ファイル

- **packages/shared/src/db/services.ts**: `rotateClientSecret()` DB関数を追加
- **workers/id/src/routes/services.ts**: `POST /:id/rotate-secret` ルートを追加
- **workers/admin/src/routes/services.ts**: admin BFF プロキシルートを追加
- **workers/id/src/routes/services.test.ts**: id worker テスト追加（6ケース）
- **workers/admin/src/routes/services.test.ts**: admin BFF テスト追加（3ケース）

## Test plan

- [ ] 認証なし → 401
- [ ] 管理者以外 → 403
- [ ] Originヘッダーなし（CSRF） → 403
- [ ] 正常系: 新しい `client_secret` が返却され、`client_secret_hash` は含まれない
- [ ] `rotateClientSecret` が正しいハッシュで呼ばれることを確認
- [ ] サービス不存在 → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added client secret rotation capability for service credentials in the admin API.
  * Added new admin endpoints for retrieving service details and managing allowed scopes.
  * Added new admin endpoint for retrieving user details with additional fields.

* **Documentation**
  * Updated API specifications with enhanced endpoint documentation and response schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->