### PR TITLE
コードレビュー: parseJsonBody のジェネリクス型引数を強化

### DIFF
--- a/workers/id/src/utils/parse-body.ts
+++ b/workers/id/src/utils/parse-body.ts
@@ -1,4 +1,4 @@
-import type { Context } from 'hono';
+import type { Context, Env } from 'hono';
 import type { z } from 'zod';
 
 /**
@@ -10,8 +10,8 @@ import type { z } from 'zod';
  * if (!result.ok) return result.response;
  * const body = result.data;
  */
-export async function parseJsonBody<T>(
-  c: Context,
+export async function parseJsonBody<T, E extends Env = Env>(
+  c: Context<E>,
   schema: z.ZodType<T>
 ): Promise<{ ok: true; data: T } | { ok: false; response: Response }> {
   let rawBody: unknown;


### PR DESCRIPTION
## Summary

- `parseJsonBody` の `Context` 型にジェネリクス引数 `E extends Env = Env` を追加
- 呼び出し元のコンテキストが持つ環境型（`IdpEnv` 等）の情報が失われないよう改善
- 関数内では `c.env` を使用していないため動作に変化なし

## Test plan

- [ ] `npm run typecheck` が全ワークスペースで通ることを確認
- [ ] 既存のルートハンドラーから `parseJsonBody` を呼び出す箇所で型エラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)