### PR TITLE
バグ修正: サービス作成時のスコープバリデーション欠落を修正

### DIFF
--- a/workers/id/src/routes/services.test.ts
+++ b/workers/id/src/routes/services.test.ts
@@ -371,6 +371,30 @@ describe('POST /api/services', () => {
       })
     );
   });
+
+  it('不正なスコープが含まれる場合 → 400を返す', async () => {
+    const res = await sendRequest(app, '/api/services', {
+      method: 'POST',
+      body: { name: 'New Service', allowed_scopes: ['profile', 'invalid_scope'] },
+      origin: 'https://admin.0g0.xyz',
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe('BAD_REQUEST');
+    expect(body.error.message).toContain('profile');
+  });
+
+  it('空のallowed_scopesを指定した場合 → 400を返す', async () => {
+    const res = await sendRequest(app, '/api/services', {
+      method: 'POST',
+      body: { name: 'New Service', allowed_scopes: [] },
+      origin: 'https://admin.0g0.xyz',
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe('BAD_REQUEST');
+    expect(body.error.message).toContain('allowed_scopes must not be empty');
+  });
 });
 
 // ===== PATCH /api/services/:id（管理者のみ）=====
@@ -426,7 +450,7 @@ describe('PATCH /api/services/:id', () => {
     expect(res.status).toBe(400);
     const body = await res.json<{ error: { code: string; message: string } }>();
     expect(body.error.code).toBe('BAD_REQUEST');
-    expect(body.error.message).toContain('invalid_scope');
+    expect(body.error.message).toContain('profile');
   });
 
   it('空配列の場合 → 400を返す', async () => {

--- a/workers/id/src/routes/services.ts
+++ b/workers/id/src/routes/services.ts
@@ -31,19 +31,18 @@ type Variables = { user: TokenPayload };
 
 // サポートされているスコープの一覧
 const SUPPORTED_SCOPES = ['profile', 'email', 'phone', 'address'] as const;
-type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
+
+const ScopeEnum = z.enum(SUPPORTED_SCOPES);
 
 const CreateServiceSchema = z.object({
   name: z.string().min(1, 'name is required'),
-  allowed_scopes: z.array(z.string()).optional(),
+  allowed_scopes: z.array(ScopeEnum).min(1, 'allowed_scopes must not be empty').optional(),
 });
 
 const PatchServiceSchema = z
   .object({
     name: z.string().min(1, 'name must not be empty').optional(),
-    allowed_scopes: z
-      .array(z.string(), { message: 'allowed_scopes must be an array' })
-      .optional(),
+    allowed_scopes: z.array(ScopeEnum).min(1, 'allowed_scopes must not be empty').optional(),
   })
   .refine((data) => data.name !== undefined || data.allowed_scopes !== undefined, {
     message: 'At least one of name or allowed_scopes must be provided',
@@ -139,30 +138,6 @@ app.patch('/:id', authMiddleware, adminMiddleware, csrfMiddleware, async (c) => 
   const result = await parseJsonBody(c, PatchServiceSchema);
   if (!result.ok) return result.response;
   const { name, allowed_scopes } = result.data;
-
-  // allowed_scopesが指定された場合はバリデーション
-  if (allowed_scopes !== undefined) {
-    const invalidScopes = allowed_scopes.filter(
-      (s) => !SUPPORTED_SCOPES.includes(s as SupportedScope)
-    );
-    if (invalidScopes.length > 0) {
-      return c.json(
-        {
-          error: {
-            code: 'BAD_REQUEST',
-            message: `Invalid scopes: ${invalidScopes.join(', ')}. Supported scopes: ${SUPPORTED_SCOPES.join(', ')}`,
-          },
-        },
-        400
-      );
-    }
-    if (allowed_scopes.length === 0) {
-      return c.json(
-        { error: { code: 'BAD_REQUEST', message: 'allowed_scopes must not be empty' } },
-        400
-      );
-    }
-  }
 
   const updated = await updateServiceFields(c.env.DB, serviceId, {
     ...(name !== undefined ? { name: name.trim() } : {}),


### PR DESCRIPTION
## Summary

- `CreateServiceSchema` に `z.enum(SUPPORTED_SCOPES)` を使用したスコープ検証を追加。POSTでサービス作成時に不正なスコープ文字列を拒否できていなかったバグを修正
- `PatchServiceSchema` も同様に `z.enum` ベースに変更し、PATCH ハンドラー内の手動バリデーションブロックを削除して一元化
- `ScopeEnum` 定数を追加し、Create/Patch 両スキーマで共有

## Test plan

- [x] `POST /api/services` に不正スコープを渡すと 400 を返すテストを追加
- [x] `POST /api/services` に空の `allowed_scopes` を渡すと 400 を返すテストを追加
- [x] `PATCH /api/services/:id` の不正スコープテストのエラーメッセージ期待値を更新
- [x] 全327テスト通過確認済み
- [x] TypeScriptの型チェック通過確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation for the `/api/services` endpoints to enforce valid scope requirements and prevent empty scope arrays.
  * Enhanced error messages for invalid scope submissions in service creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->