### PR TITLE
新機能: ユーザー自己アカウント削除機能を実装

### DIFF
--- a/workers/id/src/routes/users.test.ts
+++ b/workers/id/src/routes/users.test.ts
@@ -1518,3 +1518,77 @@ describe('DELETE /api/users/:id/tokens', () => {
     expect(vi.mocked(revokeUserTokens)).toHaveBeenCalledWith(expect.anything(), 'user-1');
   });
 });
+
+// ===== DELETE /api/users/me — 自己アカウント削除 =====
+describe('DELETE /api/users/me', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(verifyAccessToken).mockResolvedValue(mockUserPayload);
+    vi.mocked(findUserById).mockResolvedValue({ ...mockUser, id: mockUserPayload.sub });
+    vi.mocked(countServicesByOwner).mockResolvedValue(0);
+    vi.mocked(revokeUserTokens).mockResolvedValue(undefined);
+    vi.mocked(deleteUser).mockResolvedValue(true);
+  });
+
+  it('Authorizationヘッダーなし → 401を返す', async () => {
+    const res = await sendRequest(app, '/api/users/me', {
+      method: 'DELETE',
+      origin: 'https://id.0g0.xyz',
+      withAuth: false,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('Originヘッダーなし（CSRF） → 403を返す', async () => {
+    const res = await sendRequest(app, '/api/users/me', { method: 'DELETE' });
+    expect(res.status).toBe(403);
+  });
+
+  it('ユーザーが存在しない → 404を返す', async () => {
+    vi.mocked(findUserById).mockResolvedValue(null);
+    const res = await sendRequest(app, '/api/users/me', {
+      method: 'DELETE',
+      origin: 'https://id.0g0.xyz',
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('サービスを所有している場合 → 409を返す', async () => {
+    vi.mocked(countServicesByOwner).mockResolvedValue(2);
+    const res = await sendRequest(app, '/api/users/me', {
+      method: 'DELETE',
+      origin: 'https://id.0g0.xyz',
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json<{ error: { code: string; message: string } }>();
+    expect(body.error.code).toBe('CONFLICT');
+    expect(body.error.message).toContain('2 service(s)');
+  });
+
+  it('トークンを失効してからユーザーを削除し204を返す', async () => {
+    const res = await sendRequest(app, '/api/users/me', {
+      method: 'DELETE',
+      origin: 'https://id.0g0.xyz',
+    });
+    expect(res.status).toBe(204);
+    expect(vi.mocked(revokeUserTokens)).toHaveBeenCalledWith(expect.anything(), mockUserPayload.sub);
+    expect(vi.mocked(deleteUser)).toHaveBeenCalledWith(expect.anything(), mockUserPayload.sub);
+  });
+
+  it('revokeUserTokensがdeleteUserより先に呼ばれる', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(revokeUserTokens).mockImplementation(async () => { callOrder.push('revoke'); });
+    vi.mocked(deleteUser).mockImplementation(async () => { callOrder.push('delete'); return true; });
+
+    await sendRequest(app, '/api/users/me', {
+      method: 'DELETE',
+      origin: 'https://id.0g0.xyz',
+    });
+
+    expect(callOrder).toEqual(['revoke', 'delete']);
+  });
+});

--- a/workers/id/src/routes/users.ts
+++ b/workers/id/src/routes/users.ts
@@ -192,6 +192,36 @@ app.delete('/me/tokens', authMiddleware, csrfMiddleware, async (c) => {
   return c.body(null, 204);
 });
 
+// DELETE /api/users/me — 自分のアカウントを削除
+app.delete('/me', authMiddleware, csrfMiddleware, async (c) => {
+  const tokenUser = c.get('user');
+
+  const targetUser = await findUserById(c.env.DB, tokenUser.sub);
+  if (!targetUser) {
+    return c.json({ error: { code: 'NOT_FOUND', message: 'User not found' } }, 404);
+  }
+
+  // サービスの所有者である場合は削除不可（所有権を先に移譲すること）
+  const ownedServices = await countServicesByOwner(c.env.DB, tokenUser.sub);
+  if (ownedServices > 0) {
+    return c.json(
+      {
+        error: {
+          code: 'CONFLICT',
+          message: `User owns ${ownedServices} service(s). Transfer ownership before deleting.`,
+        },
+      },
+      409
+    );
+  }
+
+  // 削除前にトークンを失効
+  await revokeUserTokens(c.env.DB, tokenUser.sub);
+  await deleteUser(c.env.DB, tokenUser.sub);
+
+  return c.body(null, 204);
+});
+
 // GET /api/users/:id（管理者のみ）
 app.get('/:id', authMiddleware, adminMiddleware, async (c) => {
   const targetId = c.req.param('id');

--- a/workers/user/src/routes/profile.test.ts
+++ b/workers/user/src/routes/profile.test.ts
@@ -261,4 +261,111 @@ describe('user BFF — /api/me', () => {
       expect(res.status).toBe(500);
     });
   });
+
+  describe('DELETE / — アカウント削除', () => {
+    it('セッションなしで401を返す', async () => {
+      const idpFetch = vi.fn();
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/me', { method: 'DELETE' });
+
+      expect(res.status).toBe(401);
+      expect(idpFetch).not.toHaveBeenCalled();
+    });
+
+    it('セッションありでIdPにDELETEして204を返す', async () => {
+      const idpFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/me', {
+        method: 'DELETE',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      expect(res.status).toBe(204);
+    });
+
+    it('IdPの /api/users/me エンドポイントをDELETEで呼び出す', async () => {
+      const idpFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      const app = buildApp(idpFetch);
+
+      await app.request('/api/me', {
+        method: 'DELETE',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      const [calledReq] = (idpFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [Request];
+      expect(calledReq.method).toBe('DELETE');
+      expect(calledReq.url).toBe('https://id.0g0.xyz/api/users/me');
+    });
+
+    it('AuthorizationヘッダーにアクセストークンをBearerで付与する', async () => {
+      const idpFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      const app = buildApp(idpFetch);
+
+      await app.request('/api/me', {
+        method: 'DELETE',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      const [calledReq] = (idpFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [Request];
+      expect(calledReq.headers.get('Authorization')).toBe('Bearer mock-access-token');
+    });
+
+    it('OriginヘッダーをIdPのoriginに設定して送信する', async () => {
+      const idpFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      const app = buildApp(idpFetch);
+
+      await app.request('/api/me', {
+        method: 'DELETE',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      const [calledReq] = (idpFetch as ReturnType<typeof vi.fn>).mock.calls[0] as [Request];
+      expect(calledReq.headers.get('Origin')).toBe('https://id.0g0.xyz');
+    });
+
+    it('削除成功時にセッションCookieを削除するSet-Cookieヘッダーを返す', async () => {
+      const idpFetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/me', {
+        method: 'DELETE',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      expect(res.status).toBe(204);
+      const setCookie = res.headers.get('Set-Cookie');
+      expect(setCookie).not.toBeNull();
+      expect(setCookie).toContain(SESSION_COOKIE);
+    });
+
+    it('IdPが409（サービス所有）を返した場合はそのまま伝播する', async () => {
+      const idpFetch = mockIdp(409, {
+        error: { code: 'CONFLICT', message: 'User owns 1 service(s). Transfer ownership before deleting.' },
+      });
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/me', {
+        method: 'DELETE',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      expect(res.status).toBe(409);
+      const body = await res.json<{ error: { code: string } }>();
+      expect(body.error.code).toBe('CONFLICT');
+    });
+
+    it('IdPが500を返した場合はそのまま伝播する', async () => {
+      const idpFetch = mockIdp(500, { error: { code: 'INTERNAL_ERROR' } });
+      const app = buildApp(idpFetch);
+
+      const res = await app.request('/api/me', {
+        method: 'DELETE',
+        headers: { Cookie: `${SESSION_COOKIE}=${makeSessionCookie()}` },
+      });
+
+      expect(res.status).toBe(500);
+    });
+  });
 });

--- a/workers/user/src/routes/profile.ts
+++ b/workers/user/src/routes/profile.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { deleteCookie } from 'hono/cookie';
 import { fetchWithAuth, fetchWithJsonBody, proxyResponse } from '@0g0-id/shared';
 import type { BffEnv } from '@0g0-id/shared';
 import { SESSION_COOKIE } from './auth';
@@ -23,6 +24,19 @@ app.get('/login-history', async (c) => {
 // PATCH /api/me
 app.patch('/', async (c) => {
   return fetchWithJsonBody(c, SESSION_COOKIE, `${c.env.IDP_ORIGIN}/api/users/me`, 'PATCH');
+});
+
+// DELETE /api/me — アカウント削除（セッションCookieも削除）
+app.delete('/', async (c) => {
+  const res = await fetchWithAuth(c, SESSION_COOKIE, `${c.env.IDP_ORIGIN}/api/users/me`, {
+    method: 'DELETE',
+    headers: { Origin: c.env.IDP_ORIGIN },
+  });
+  if (res.status === 204) {
+    deleteCookie(c, SESSION_COOKIE, { path: '/', secure: true });
+    return c.body(null, 204);
+  }
+  return proxyResponse(res);
 });
 
 export default app;


### PR DESCRIPTION
## Summary

- IdP に `DELETE /api/users/me` エンドポイントを追加（認証済みユーザーが自分自身を削除）
- サービスを所有している場合は `409 CONFLICT` で拒否し、所有権移譲を要求
- 削除前にすべてのリフレッシュトークンを失効させてからアカウントを削除
- user BFF に `DELETE /api/me` エンドポイントを追加（IdP へプロキシ）
- 削除成功時（204）にセッション Cookie を自動削除し、クライアントを即座にログアウト

## Test plan

- [ ] IdP: `DELETE /api/users/me` — 認証なし → 401
- [ ] IdP: `DELETE /api/users/me` — CSRF（Originなし） → 403
- [ ] IdP: `DELETE /api/users/me` — ユーザー不存在 → 404
- [ ] IdP: `DELETE /api/users/me` — サービス所有者 → 409
- [ ] IdP: `DELETE /api/users/me` — 成功時にトークン失効→削除の順序を保証し 204
- [ ] user BFF: `DELETE /api/me` — セッションなし → 401
- [ ] user BFF: `DELETE /api/me` — 成功時に 204 かつセッション Cookie 削除
- [ ] user BFF: `DELETE /api/me` — IdP 409/500 はそのまま伝播

全 355 + 88 テスト通過確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete their own accounts through self-service account deletion.
  * Account deletion is blocked if the user owns active services, preventing service orphaning.
  * User sessions are automatically cleared upon successful account deletion.

* **Tests**
  * Added comprehensive test coverage for the account deletion feature across integration points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->