### PR TITLE
セキュリティ対応: 管理者でないユーザーのログイン時にリフレッシュトークンを失効させる

### DIFF
--- a/workers/admin/src/routes/auth.test.ts
+++ b/workers/admin/src/routes/auth.test.ts
@@ -130,7 +130,7 @@ describe('admin BFF — /auth', () => {
       expect(res.headers.get('location')).toBe('/?error=exchange_failed');
     });
 
-    it('管理者以外のユーザー → /?error=not_adminにリダイレクト', async () => {
+    it('管理者以外のユーザー → リフレッシュトークンを失効してから/?error=not_adminにリダイレクト', async () => {
       const idpFetch = buildIdpFetch(200, makeExchangeResponse('user'));
       const app = buildApp(idpFetch);
 
@@ -140,6 +140,15 @@ describe('admin BFF — /auth', () => {
 
       expect(res.status).toBe(302);
       expect(res.headers.get('location')).toBe('/?error=not_admin');
+
+      // IdPにlogoutリクエストが送信されてリフレッシュトークンが失効されることを確認
+      expect(idpFetch).toHaveBeenCalledTimes(2);
+      const calls = (idpFetch as ReturnType<typeof vi.fn>).mock.calls as [Request][];
+      const logoutReq = calls[1][0];
+      expect(logoutReq.url).toBe('https://id.0g0.xyz/auth/logout');
+      expect(logoutReq.method).toBe('POST');
+      const logoutBody = await logoutReq.json<{ refresh_token: string }>();
+      expect(logoutBody.refresh_token).toBe('mock-refresh-token');
     });
 
     it('管理者ユーザー → セッションCookieをセットして/dashboard.htmlにリダイレクト', async () => {

--- a/workers/admin/src/routes/auth.ts
+++ b/workers/admin/src/routes/auth.ts
@@ -74,6 +74,18 @@ app.get('/callback', async (c) => {
 
   // 管理者チェック
   if (exchangeData.data.user.role !== 'admin') {
+    // 非管理者ユーザーのリフレッシュトークンを失効させる（孤立トークン防止）
+    try {
+      await c.env.IDP.fetch(
+        new Request(`${c.env.IDP_ORIGIN}/auth/logout`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh_token: exchangeData.data.refresh_token }),
+        })
+      );
+    } catch {
+      // 失効に失敗してもリダイレクトは継続
+    }
     return c.redirect('/?error=not_admin');
   }
 


### PR DESCRIPTION
## 問題

管理者画面BFF（`workers/admin`）のOAuthコールバックハンドラーで、管理者でないユーザーがログインを試みた際の挙動に問題がありました。

**修正前のフロー:**
1. IdPでコード交換 → アクセストークン + リフレッシュトークン発行
2. ユーザーの `role !== 'admin'` を確認
3. **リフレッシュトークンを失効させずに** `/?error=not_admin` へリダイレクト

このため、管理者でないユーザーのリフレッシュトークンがDBに残り続けていました（最大30日間）。

## 修正内容

`/?error=not_admin` へリダイレクトする前に `/auth/logout` を呼び出してリフレッシュトークンを即時失効させるよう修正しました。

- 失効リクエストが失敗した場合もリダイレクトは継続（堅牢性維持）
- テストを更新してトークン失効が行われることを検証

## テスト

- 全テスト通過: 47ファイル / 947テスト ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication security by invalidating refresh tokens for non-admin users during login attempts, preventing potential token reuse.

* **Tests**
  * Updated authentication tests to verify refresh token invalidation for denied login attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->