### PR TITLE
新機能: ユーザーリストへのbannedフィルター追加・メトリクスにbanned_users追加

### DIFF
--- a/packages/shared/src/db/users.test.ts
+++ b/packages/shared/src/db/users.test.ts
@@ -506,6 +506,25 @@ describe('listUsers', () => {
     const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(sql).not.toContain('WHERE');
   });
+
+  it('banned=trueフィルターでBAN済みユーザーのみ検索する', async () => {
+    const bannedUser = { ...baseUser, banned_at: '2026-03-24T00:00:00Z' };
+    const stmt = { bind: vi.fn().mockReturnThis(), all: vi.fn().mockResolvedValue({ results: [bannedUser] }) };
+    const db = { prepare: vi.fn().mockReturnValue(stmt) } as unknown as D1Database;
+    await listUsers(db, 10, 0, { banned: true });
+    const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain('banned_at IS NOT NULL');
+    expect(stmt.bind).toHaveBeenCalledWith(10, 0);
+  });
+
+  it('banned=falseフィルターでBAN済みを除外して検索する', async () => {
+    const stmt = { bind: vi.fn().mockReturnThis(), all: vi.fn().mockResolvedValue({ results: [baseUser] }) };
+    const db = { prepare: vi.fn().mockReturnValue(stmt) } as unknown as D1Database;
+    await listUsers(db, 10, 0, { banned: false });
+    const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain('banned_at IS NULL');
+    expect(stmt.bind).toHaveBeenCalledWith(10, 0);
+  });
 });
 
 describe('countUsers', () => {
@@ -542,6 +561,22 @@ describe('countUsers', () => {
     await countUsers(db, {});
     const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
     expect(sql).not.toContain('WHERE');
+  });
+
+  it('banned=trueフィルターでBAN済みユーザー数を返す', async () => {
+    const db = makeD1Mock({ count: 3 });
+    const count = await countUsers(db, { banned: true });
+    expect(count).toBe(3);
+    const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain('banned_at IS NOT NULL');
+  });
+
+  it('banned=falseフィルターでBAN済み除外の件数を返す', async () => {
+    const db = makeD1Mock({ count: 97 });
+    const count = await countUsers(db, { banned: false });
+    expect(count).toBe(97);
+    const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain('banned_at IS NULL');
   });
 });
 

--- a/packages/shared/src/db/users.ts
+++ b/packages/shared/src/db/users.ts
@@ -359,6 +359,8 @@ export interface UserFilter {
   email?: string;
   role?: 'user' | 'admin';
   name?: string;
+  /** true: BAN済みのみ / false: BAN済み除外 / undefined: 全件 */
+  banned?: boolean;
 }
 
 function buildUserFilterClause(filter?: UserFilter): { where: string; params: unknown[] } {
@@ -376,6 +378,11 @@ function buildUserFilterClause(filter?: UserFilter): { where: string; params: un
   if (filter?.name) {
     conditions.push('name LIKE ?');
     params.push(`%${filter.name}%`);
+  }
+  if (filter?.banned === true) {
+    conditions.push('banned_at IS NOT NULL');
+  } else if (filter?.banned === false) {
+    conditions.push('banned_at IS NULL');
   }
 
   return {

--- a/workers/admin/src/routes/users.ts
+++ b/workers/admin/src/routes/users.ts
@@ -13,9 +13,11 @@ app.get('/', async (c) => {
   const email = c.req.query('email');
   const role = c.req.query('role');
   const name = c.req.query('name');
+  const banned = c.req.query('banned');
   if (email) url.searchParams.set('email', email);
   if (role) url.searchParams.set('role', role);
   if (name) url.searchParams.set('name', name);
+  if (banned === 'true' || banned === 'false') url.searchParams.set('banned', banned);
 
   const res = await fetchWithAuth(c, SESSION_COOKIE, url.toString());
   return proxyResponse(res);

--- a/workers/id/src/routes/metrics.test.ts
+++ b/workers/id/src/routes/metrics.test.ts
@@ -95,7 +95,8 @@ describe('GET /api/metrics', () => {
 
   it('管理者トークンでメトリクスデータを返す', async () => {
     vi.mocked(verifyAccessToken).mockResolvedValue(mockAdminPayload);
-    vi.mocked(countUsers).mockResolvedValue(100);
+    // 1回目: 全ユーザー数, 2回目: BAN済みユーザー数
+    vi.mocked(countUsers).mockResolvedValueOnce(100).mockResolvedValueOnce(3);
     vi.mocked(countAdminUsers).mockResolvedValue(5);
     vi.mocked(countServices).mockResolvedValue(10);
     vi.mocked(countActiveRefreshTokens).mockResolvedValue(42);
@@ -117,6 +118,7 @@ describe('GET /api/metrics', () => {
       data: {
         total_users: number;
         admin_users: number;
+        banned_users: number;
         total_services: number;
         active_sessions: number;
         recent_logins_24h: number;
@@ -126,6 +128,7 @@ describe('GET /api/metrics', () => {
     }>();
     expect(body.data.total_users).toBe(100);
     expect(body.data.admin_users).toBe(5);
+    expect(body.data.banned_users).toBe(3);
     expect(body.data.total_services).toBe(10);
     expect(body.data.active_sessions).toBe(42);
     expect(body.data.recent_logins_24h).toBe(13);
@@ -153,6 +156,7 @@ describe('GET /api/metrics', () => {
     );
 
     expect(vi.mocked(countUsers)).toHaveBeenCalledWith(mockEnv.DB);
+    expect(vi.mocked(countUsers)).toHaveBeenCalledWith(mockEnv.DB, { banned: true });
     expect(vi.mocked(countAdminUsers)).toHaveBeenCalledWith(mockEnv.DB);
     expect(vi.mocked(countServices)).toHaveBeenCalledWith(mockEnv.DB);
     expect(vi.mocked(countActiveRefreshTokens)).toHaveBeenCalledWith(mockEnv.DB);

--- a/workers/id/src/routes/metrics.ts
+++ b/workers/id/src/routes/metrics.ts
@@ -21,10 +21,11 @@ app.get('/', authMiddleware, adminMiddleware, async (c) => {
   const since24h = new Date(now - 24 * 60 * 60 * 1000).toISOString();
   const since7d = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString();
 
-  const [totalUsers, adminUsers, totalServices, activeTokens, recentLogins24h, recentLogins7d, providerStats7d] =
+  const [totalUsers, adminUsers, bannedUsers, totalServices, activeTokens, recentLogins24h, recentLogins7d, providerStats7d] =
     await Promise.all([
       countUsers(c.env.DB),
       countAdminUsers(c.env.DB),
+      countUsers(c.env.DB, { banned: true }),
       countServices(c.env.DB),
       countActiveRefreshTokens(c.env.DB),
       countRecentLoginEvents(c.env.DB, since24h),
@@ -36,6 +37,7 @@ app.get('/', authMiddleware, adminMiddleware, async (c) => {
     data: {
       total_users: totalUsers,
       admin_users: adminUsers,
+      banned_users: bannedUsers,
       total_services: totalServices,
       active_sessions: activeTokens,
       recent_logins_24h: recentLogins24h,

--- a/workers/id/src/routes/users.ts
+++ b/workers/id/src/routes/users.ts
@@ -538,10 +538,13 @@ app.get('/', authMiddleware, adminMiddleware, async (c) => {
   const emailQuery = c.req.query('email');
   const roleQuery = c.req.query('role');
   const nameQuery = c.req.query('name');
+  const bannedQuery = c.req.query('banned');
 
   if (emailQuery) filter.email = emailQuery;
   if (roleQuery === 'user' || roleQuery === 'admin') filter.role = roleQuery;
   if (nameQuery) filter.name = nameQuery;
+  if (bannedQuery === 'true') filter.banned = true;
+  else if (bannedQuery === 'false') filter.banned = false;
 
   const [users, total] = await Promise.all([
     listUsers(c.env.DB, limit, offset, filter),


### PR DESCRIPTION
## Summary

- `UserFilter` に `banned?: boolean` フィールドを追加し、BAN済みユーザーのフィルタリングを可能にした
- `GET /api/users?banned=true/false` でBAN済み／非BAN済みユーザーの絞り込みができるようになった
- `GET /api/metrics` のレスポンスに `banned_users` カウントを追加した
- admin BFF でも `banned` クエリパラメーターを IDP に転送するよう対応した

## Test plan

- [ ] `packages/shared` のテストで `banned=true/false` フィルターの SQL 生成を確認
- [ ] `workers-id` のテストで metrics に `banned_users` が含まれることを確認
- [ ] 全 workspace で `npm test` がグリーンであることを確認（計 997 tests passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to filter users by ban status (banned or active) when querying user lists across the API
  * Metrics endpoint now includes a count of banned users in its response

<!-- end of auto-generated comment: release notes by coderabbit.ai -->