### PR TITLE
セキュリティ対応: 外部サービスへの client_id 必須化・監査ログエラー非致死化

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -51,6 +51,30 @@ paths:
 |------|----------|------|------|
 | /api/health | GET | Public | ヘルスチェック |
 | /auth/login | GET | Public | Google認可へリダイレクト |
+
+### /auth/login クエリパラメータ
+
+| パラメータ | 必須/任意 | 説明 |
+|---|---|---|
+| `redirect_to` | 必須 | 認証後のリダイレクト先 URI |
+| `state` | 推奨 | CSRF 防止用の不透明な文字列 |
+| `client_id` | **外部サービスでは必須** | 登録済みサービスの client_id |
+| `code_challenge` | PKCE 使用時 | S256 コードチャレンジ |
+| `code_challenge_method` | PKCE 使用時 | `S256` 固定 |
+
+#### client_id の扱い
+
+- **BFF オリジン**（`user.0g0.xyz`, `admin.0g0.xyz`, `EXTRA_BFF_ORIGINS`）: `client_id` は省略可
+- **外部サービス**（非 BFF オリジン、例: `rss.0g0.xyz`）: `client_id` は**必須**
+
+`client_id` なしで外部オリジンから呼び出した場合:
+- `400 Bad Request` — `{ "error": { "code": "BAD_REQUEST", "message": "client_id is required for external services" } }`
+- ユーザーとサービスの紐付けが記録されないため `/api/users/me/connections` に表示されない
+
+外部サービスのログイン URL 形式:
+```
+https://id.0g0.xyz/auth/login?client_id=<CLIENT_ID>&redirect_to=<登録済みURI>&state=<STATE>
+```
 | /auth/callback | GET | Public | Googleコールバック |
 | /auth/exchange | POST | Service Bindings | ワンタイムコード交換 |
 | /auth/logout | POST | Service Bindings | ログアウト |

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ BOOTSTRAP_ADMIN_EMAIL=admin@example.com
 
 ## 認証フロー
 
+### BFF フロー（user.0g0.xyz / admin.0g0.xyz）
+
 ```
 ブラウザ → user.0g0.xyz/auth/login
   → state + PKCE 生成 → Cookie 保存
@@ -120,6 +122,31 @@ BOOTSTRAP_ADMIN_EMAIL=admin@example.com
   → id への内部 API（Service Bindings）でコード交換
   → __Host- Cookie にトークン設定
 ```
+
+### 外部サービスフロー（rss.0g0.xyz 等の非 BFF オリジン）
+
+外部サービスが `/auth/login` を呼び出す場合は **`client_id` が必須**です。
+
+```
+ブラウザ → https://id.0g0.xyz/auth/login
+              ?client_id=<CLIENT_ID>
+              &redirect_to=<登録済みリダイレクトURI>
+              &state=<STATE>
+  → Google 認可画面
+  → id.0g0.xyz/auth/callback
+  → 認可コードを redirect_to に付与してリダイレクト
+  → 外部サービスが /auth/exchange でトークン交換
+```
+
+#### client_id の必須ルール
+
+| 呼び出し元 | client_id | 動作 |
+|---|---|---|
+| BFF オリジン（user.0g0.xyz, admin.0g0.xyz, EXTRA_BFF_ORIGINS） | 省略可 | BFF フローで処理 |
+| 外部サービス（非 BFF オリジン） | **必須** | 省略すると 400 エラー |
+
+- `client_id` なしで外部オリジンから呼び出すと `400 Bad Request` — `"client_id is required for external services"`
+- `client_id` なしでログインするとユーザーとサービスの関係が記録されず、`/api/users/me/connections`（連携サービス一覧）に表示されない
 
 ## API
 

--- a/workers/id/src/routes/auth.ts
+++ b/workers/id/src/routes/auth.ts
@@ -173,7 +173,63 @@ export function isAllowedRedirectTo(
   return false;
 }
 
+/**
+ * redirect_to が既知のBFFオリジン（USER_ORIGIN / ADMIN_ORIGIN / EXTRA_BFF_ORIGINS）と
+ * 完全一致するかを検証する。
+ * isAllowedRedirectTo と異なり、*.0g0.xyz のようなワイルドカードマッチは行わない。
+ */
+export function isBffOrigin(
+  redirectTo: string,
+  userOrigin: string,
+  adminOrigin: string,
+  extraBffOrigins?: string
+): boolean {
+  let redirectUrl: URL;
+  try {
+    redirectUrl = new URL(redirectTo);
+  } catch {
+    return false;
+  }
+
+  // HTTPS のみ許可
+  if (redirectUrl.protocol !== 'https:') return false;
+
+  // USER_ORIGIN / ADMIN_ORIGIN と origin 単位で完全一致比較
+  const bffOrigins = [userOrigin, adminOrigin];
+  if (bffOrigins.some((o) => {
+    try {
+      return redirectUrl.origin === new URL(o).origin;
+    } catch {
+      return false;
+    }
+  })) {
+    return true;
+  }
+
+  // EXTRA_BFF_ORIGINS による追加オリジン（外部ドメイン向け）
+  if (extraBffOrigins) {
+    const extras = extraBffOrigins
+      .split(',')
+      .map((o) => o.trim())
+      .filter(Boolean);
+    if (
+      extras.some((extra) => {
+        try {
+          return redirectUrl.origin === new URL(extra).origin;
+        } catch {
+          return false;
+        }
+      })
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function setSecureCookie(
+
   c: Context<{ Bindings: IdpEnv; Variables: Variables }>,
   name: string,
   value: string,
@@ -548,8 +604,18 @@ app.get('/login', authRateLimitMiddleware, async (c) => {
     }
     serviceId = service.id;
   } else {
-    const allowed = isAllowedRedirectTo(redirectTo, c.env.IDP_ORIGIN, c.env.EXTRA_BFF_ORIGINS);
-    if (!allowed) {
+    // client_id なしは BFF オリジン（USER_ORIGIN / ADMIN_ORIGIN / EXTRA_BFF_ORIGINS）のみ許可
+    const isBff = isBffOrigin(redirectTo, c.env.USER_ORIGIN, c.env.ADMIN_ORIGIN, c.env.EXTRA_BFF_ORIGINS);
+    if (!isBff) {
+      // redirect_to が *.0g0.xyz など同一ベースドメインに属していても、
+      // client_id なしでの外部サービスフローは拒否する
+      const isKnownDomain = isAllowedRedirectTo(redirectTo, c.env.IDP_ORIGIN, c.env.EXTRA_BFF_ORIGINS);
+      if (isKnownDomain) {
+        return c.json(
+          { error: { code: 'BAD_REQUEST', message: 'client_id is required for external services' } },
+          400
+        );
+      }
       return c.json({ error: { code: 'BAD_REQUEST', message: 'Invalid redirect_to' } }, 400);
     }
   }

--- a/workers/id/src/routes/users.ts
+++ b/workers/id/src/routes/users.ts
@@ -497,16 +497,26 @@ app.patch('/:id/ban', authMiddleware, adminMiddleware, csrfMiddleware, async (c)
     return c.json({ error: { code: 'CONFLICT', message: 'User is already banned' } }, 409);
   }
 
-  const updated = await banUser(c.env.DB, targetId);
-  // 停止と同時に全セッション失効
-  await revokeUserTokens(c.env.DB, targetId);
-  await createAdminAuditLog(c.env.DB, {
-    adminUserId: tokenUser.sub,
-    action: 'user.ban',
-    targetType: 'user',
-    targetId,
-    ipAddress: c.req.header('CF-Connecting-IP') ?? c.req.header('X-Forwarded-For') ?? null,
-  });
+  let updated;
+  try {
+    updated = await banUser(c.env.DB, targetId);
+    // 停止と同時に全セッション失効
+    await revokeUserTokens(c.env.DB, targetId);
+  } catch {
+    return c.json({ error: { code: 'INTERNAL_ERROR', message: 'Failed to ban user' } }, 500);
+  }
+
+  try {
+    await createAdminAuditLog(c.env.DB, {
+      adminUserId: tokenUser.sub,
+      action: 'user.ban',
+      targetType: 'user',
+      targetId,
+      ipAddress: c.req.header('CF-Connecting-IP') ?? c.req.header('X-Forwarded-For') ?? null,
+    });
+  } catch (err) {
+    console.error('Failed to create audit log for user.ban:', err);
+  }
 
   return c.json({ data: formatAdminUserSummary(updated) });
 });
@@ -621,13 +631,17 @@ app.delete('/:id', authMiddleware, adminMiddleware, csrfMiddleware, async (c) =>
     return c.json({ error: deleteError }, 409);
   }
 
-  await createAdminAuditLog(c.env.DB, {
-    adminUserId: tokenUser.sub,
-    action: 'user.delete',
-    targetType: 'user',
-    targetId,
-    ipAddress: c.req.header('CF-Connecting-IP') ?? c.req.header('X-Forwarded-For') ?? null,
-  });
+  try {
+    await createAdminAuditLog(c.env.DB, {
+      adminUserId: tokenUser.sub,
+      action: 'user.delete',
+      targetType: 'user',
+      targetId,
+      ipAddress: c.req.header('CF-Connecting-IP') ?? c.req.header('X-Forwarded-For') ?? null,
+    });
+  } catch (err) {
+    console.error('Failed to create audit log for user.delete:', err);
+  }
 
   return c.body(null, 204);
 });


### PR DESCRIPTION
## Summary

- `/auth/login` に `isBffOrigin()` を追加し、非 BFF オリジン（`rss.0g0.xyz` 等）からの `client_id` なしログインを 400 で拒否
- `*.0g0.xyz` ワイルドカード許可から `USER_ORIGIN`/`ADMIN_ORIGIN`/`EXTRA_BFF_ORIGINS` との完全一致チェックへ変更
- ユーザー ban/delete エンドポイントの `createAdminAuditLog` 失敗を非致死化（監査ログ失敗でも主操作は成功を返す）
- README・`api.md` に BFF フロー vs 外部サービスフローの違いと `client_id` 必須ルールを追記

## Test plan

- [ ] `client_id` なしで `rss.0g0.xyz` からログイン → 400 `client_id is required for external services` が返る
- [ ] `client_id` なしで `user.0g0.xyz` からログイン → 従来通り通過する
- [ ] `client_id` あり（登録済みサービス）でログイン → 通過し `service_id` が記録される
- [ ] ban エンドポイント実行 → 成功レスポンスが返る
- [ ] delete エンドポイント実行 → 204 が返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)