### PR TITLE
リファクタリング: IDトークン発行ロジックを issueIdToken に共通化

### DIFF
--- a/workers/id/src/routes/device.test.ts
+++ b/workers/id/src/routes/device.test.ts
@@ -26,6 +26,7 @@ vi.mock("@0g0-id/shared", () => ({
 vi.mock("../utils/token-pair", () => ({
   issueTokenPair: vi.fn(),
   buildTokenResponse: vi.fn(),
+  issueIdToken: vi.fn(),
 }));
 
 // scopes ユーティリティのモック
@@ -69,11 +70,10 @@ import {
   denyDeviceCode,
   createDeviceCode,
   deleteExpiredDeviceCodes,
-  signIdToken,
 } from "@0g0-id/shared";
 import { parseAllowedScopes } from "../utils/scopes";
 
-import { issueTokenPair, buildTokenResponse } from "../utils/token-pair";
+import { issueTokenPair, buildTokenResponse, issueIdToken } from "../utils/token-pair";
 import { resolveEffectiveScope } from "../utils/scopes";
 
 import deviceRoutes, { handleDeviceCodeGrant } from "./device";
@@ -346,16 +346,13 @@ describe("handleDeviceCodeGrant", () => {
     expect(body.token_type).toBe("Bearer");
   });
 
-  it("承認済み（openid スコープあり）→ signIdToken が呼ばれる", async () => {
+  it("承認済み（openid スコープあり）→ issueIdToken が呼ばれる", async () => {
     vi.mocked(findDeviceCodeByHash).mockResolvedValue(approvedDeviceCode as never);
-    vi.mocked(sha256)
-      .mockResolvedValueOnce("hashed-device-code") // device_code ハッシュ
-      .mockResolvedValueOnce("pairwise-sub"); // pairwise sub
-    vi.mocked(signIdToken).mockResolvedValue("mock-id-token");
+    vi.mocked(issueIdToken).mockResolvedValue("mock-id-token");
     vi.mocked(resolveEffectiveScope).mockReturnValue("openid profile");
     const c = makeContext();
     await handleDeviceCodeGrant(c as never, baseParams);
-    expect(signIdToken).toHaveBeenCalled();
+    expect(issueIdToken).toHaveBeenCalled();
   });
 
   it("全スコープが無効（resolveEffectiveScope → undefined）→ invalid_scope + 400", async () => {

--- a/workers/id/src/routes/device.ts
+++ b/workers/id/src/routes/device.ts
@@ -14,7 +14,6 @@ import {
   deleteDeviceCode,
   deleteApprovedDeviceCode,
   deleteExpiredDeviceCodes,
-  signIdToken,
 } from "@0g0-id/shared";
 import type { IdpEnv, TokenPayload, Service, DeviceCode, User } from "@0g0-id/shared";
 import type { TokenHandlerContext } from "./token";
@@ -28,7 +27,7 @@ import {
   rejectBannedUserMiddleware,
 } from "../middleware/auth";
 import { resolveEffectiveScope } from "../utils/scopes";
-import { issueTokenPair, buildTokenResponse } from "../utils/token-pair";
+import { issueTokenPair, buildTokenResponse, issueIdToken } from "../utils/token-pair";
 
 const deviceLogger = createLogger("device");
 
@@ -450,27 +449,8 @@ export async function handleDeviceCodeGrant(
     clientId: service.client_id,
     scope: serviceScope,
   });
-  const pairwiseSub = await sha256(`${service.client_id}:${user.id}`);
-
   // OIDC ID トークン発行（openid スコープがある場合）
-  let idToken: string | undefined;
-  const shouldIssueIdToken = serviceScope?.split(" ").includes("openid");
-  if (shouldIssueIdToken) {
-    const authTime = Math.floor(Date.now() / 1000);
-    idToken = await signIdToken(
-      {
-        iss: c.env.IDP_ORIGIN,
-        sub: pairwiseSub,
-        aud: service.client_id,
-        email: user.email,
-        name: user.name,
-        picture: user.picture,
-        authTime,
-      },
-      c.env.JWT_PRIVATE_KEY,
-      c.env.JWT_PUBLIC_KEY,
-    );
-  }
+  const idToken = await issueIdToken(c.env, user, service, serviceScope);
 
   // レスポンス (RFC 6749 §5.1)
   return c.json(buildTokenResponse(accessToken, refreshToken, serviceScope, idToken));

--- a/workers/id/src/routes/token.ts
+++ b/workers/id/src/routes/token.ts
@@ -10,7 +10,6 @@ import {
   findAndConsumeAuthCode,
   findServiceByClientId,
   generateCodeChallenge,
-  signIdToken,
   timingSafeEqual,
   matchRedirectUri,
   normalizeRedirectUri,
@@ -26,7 +25,7 @@ import {
 import { authenticateService } from "../utils/service-auth";
 import { parseAllowedScopes, resolveEffectiveScope } from "../utils/scopes";
 import { handleDeviceCodeGrant } from "./device";
-import { issueTokenPair, buildTokenResponse } from "../utils/token-pair";
+import { issueTokenPair, buildTokenResponse, issueIdToken } from "../utils/token-pair";
 import { attemptUnrevokeToken } from "../utils/token-recovery";
 import {
   validateAndRevokeRefreshToken,
@@ -302,27 +301,10 @@ async function handleAuthorizationCodeGrant(
     });
 
     // OIDC ID トークン発行（openid スコープがある場合）
-    let idToken: string | undefined;
-    if (serviceScope?.split(" ").includes("openid")) {
-      const pairwiseSub = await sha256(`${service.client_id}:${user.id}`);
-      const authTime = Math.floor(Date.now() / 1000);
-      idToken = await signIdToken(
-        {
-          iss: c.env.IDP_ORIGIN,
-          sub: pairwiseSub,
-          aud: service.client_id,
-          email: user.email,
-          name: user.name,
-          picture: user.picture,
-          authTime,
-          nonce: authCode.nonce ?? undefined,
-          // RFC 8176: 認証方式リスト。ソーシャルログインのプロバイダーを記録する
-          amr: authCode.provider ? [authCode.provider] : undefined,
-        },
-        c.env.JWT_PRIVATE_KEY,
-        c.env.JWT_PUBLIC_KEY,
-      );
-    }
+    const idToken = await issueIdToken(c.env, user, service, serviceScope, {
+      nonce: authCode.nonce ?? undefined,
+      amr: authCode.provider ? [authCode.provider] : undefined,
+    });
 
     // レスポンス (RFC 6749 §5.1)
     return c.json(buildTokenResponse(accessToken, refreshToken, serviceScope, idToken));

--- a/workers/id/src/utils/token-pair.ts
+++ b/workers/id/src/utils/token-pair.ts
@@ -1,4 +1,10 @@
-import { generateToken, sha256, signAccessToken, createRefreshToken } from "@0g0-id/shared";
+import {
+  generateToken,
+  sha256,
+  signAccessToken,
+  signIdToken,
+  createRefreshToken,
+} from "@0g0-id/shared";
 import type { IdpEnv, User } from "@0g0-id/shared";
 
 /** リフレッシュトークンの有効期限（30日） */
@@ -74,4 +80,40 @@ export function buildTokenResponse(
   if (idToken) response["id_token"] = idToken;
   if (scope) response["scope"] = scope;
   return response;
+}
+
+/**
+ * OIDC IDトークンを発行する（openid スコープがある場合のみ）。
+ *
+ * pairwise sub の計算と signIdToken 呼び出しを共通化する。
+ */
+export async function issueIdToken(
+  env: IdpEnv,
+  user: User,
+  service: { client_id: string },
+  scope: string | undefined,
+  options?: { nonce?: string; amr?: string[] },
+): Promise<string | undefined> {
+  if (!scope?.split(" ").includes("openid")) {
+    return undefined;
+  }
+
+  const pairwiseSub = await sha256(`${service.client_id}:${user.id}`);
+  const authTime = Math.floor(Date.now() / 1000);
+
+  return signIdToken(
+    {
+      iss: env.IDP_ORIGIN,
+      sub: pairwiseSub,
+      aud: service.client_id,
+      email: user.email,
+      name: user.name,
+      picture: user.picture,
+      authTime,
+      nonce: options?.nonce,
+      amr: options?.amr,
+    },
+    env.JWT_PRIVATE_KEY,
+    env.JWT_PUBLIC_KEY,
+  );
 }


### PR DESCRIPTION
## Summary
- token.ts と device.ts に重複していた OIDC IDトークン発行ロジック（pairwise sub 計算 + signIdToken 呼び出し）を `token-pair.ts` の `issueIdToken()` ヘルパーに集約
- 両ファイルから直接の `signIdToken` import を削除し、`issueIdToken` 経由に統一
- device.test.ts のテストを `issueIdToken` モックに更新

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized ID token issuance logic into a centralized utility function for improved code organization across authentication flows.

* **Tests**
  * Updated unit tests to reflect changes in ID token handling implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->