### PR TITLE
リファクタリング: pairwise sub計算を generatePairwiseSub に共通化

### DIFF
--- a/packages/shared/src/lib/crypto.ts
+++ b/packages/shared/src/lib/crypto.ts
@@ -29,6 +29,14 @@ export async function sha256(input: string): Promise<string> {
 }
 
 /**
+ * ペアワイズsub識別子を生成する（OIDC pairwise subject）
+ * sha256(clientId:userId) でサービスごとに一意なsub値を返す
+ */
+export async function generatePairwiseSub(clientId: string, userId: string): Promise<string> {
+  return sha256(`${clientId}:${userId}`);
+}
+
+/**
  * ランダムなトークンを生成する（URLセーフbase64）
  */
 export function generateToken(byteLength: number = 32): string {

--- a/workers/id/src/routes/auth.test.ts
+++ b/workers/id/src/routes/auth.test.ts
@@ -43,6 +43,7 @@ vi.mock("@0g0-id/shared", async (importOriginal) => {
     generateCodeChallenge: vi.fn(),
     generateToken: vi.fn(),
     sha256: vi.fn(),
+    generatePairwiseSub: vi.fn(),
     signAccessToken: vi.fn(),
     signIdToken: vi.fn(),
     createRefreshToken: vi.fn(),
@@ -116,6 +117,7 @@ import {
   generateCodeChallenge,
   generateToken,
   sha256,
+  generatePairwiseSub,
   signAccessToken,
   signIdToken,
   createRefreshToken,
@@ -2040,9 +2042,9 @@ describe("POST /auth/exchange (サービスOAuth)", () => {
     // sha256 は呼び出し引数に応じて返す値を変える
     vi.mocked(sha256).mockImplementation(async (input: string) => {
       if (input === "my-secret") return "secret-hash-abc";
-      if (input.includes(":")) return "pairwise-sub-hash";
       return "hashed-code";
     });
+    vi.mocked(generatePairwiseSub).mockResolvedValue("pairwise-sub-hash");
     vi.mocked(findAndConsumeAuthCode).mockResolvedValue({
       id: "code-id",
       user_id: "user-1",

--- a/workers/id/src/routes/auth.ts
+++ b/workers/id/src/routes/auth.ts
@@ -15,6 +15,7 @@ import {
   generateCodeChallenge,
   generateToken,
   sha256,
+  generatePairwiseSub,
   signIdToken,
   findRefreshTokenByHash,
   findUserById,
@@ -726,7 +727,7 @@ app.post("/exchange", tokenApiRateLimitMiddleware, serviceBindingMiddleware, asy
 
     serviceId = service.id;
     // ペアワイズ sub（OIDC Core 1.0 §8.1）: sha256(client_id:user_id)
-    idTokenSub = await sha256(`${service.client_id}:${user.id}`);
+    idTokenSub = await generatePairwiseSub(service.client_id, user.id);
     idTokenAud = service.client_id;
     // サービストークンのスコープ: 要求スコープとサービスの allowed_scopes を交差検証
     serviceScope = resolveEffectiveScope(authCode.scope, service.allowed_scopes);

--- a/workers/id/src/routes/external.test.ts
+++ b/workers/id/src/routes/external.test.ts
@@ -10,6 +10,7 @@ vi.mock("@0g0-id/shared", async (importActual) => {
     findUserIdByPairwiseSub: vi.fn(),
     findServiceByClientId: vi.fn(),
     sha256: vi.fn(),
+    generatePairwiseSub: vi.fn(),
     timingSafeEqual: vi.fn(),
     listUsersAuthorizedForService: vi.fn(),
     countUsersAuthorizedForService: vi.fn(),
@@ -21,6 +22,7 @@ import {
   findUserIdByPairwiseSub,
   findServiceByClientId,
   sha256,
+  generatePairwiseSub,
   timingSafeEqual,
   listUsersAuthorizedForService,
   countUsersAuthorizedForService,
@@ -32,6 +34,7 @@ const mockFindUserById = vi.mocked(findUserById);
 const mockFindUserIdByPairwiseSub = vi.mocked(findUserIdByPairwiseSub);
 const mockFindServiceByClientId = vi.mocked(findServiceByClientId);
 const mockSha256 = vi.mocked(sha256);
+const mockGeneratePairwiseSub = vi.mocked(generatePairwiseSub);
 const mockTimingSafeEqual = vi.mocked(timingSafeEqual);
 const mockListUsersAuthorizedForService = vi.mocked(listUsersAuthorizedForService);
 const mockCountUsersAuthorizedForService = vi.mocked(countUsersAuthorizedForService);
@@ -140,10 +143,10 @@ describe("GET /api/external/users/:sub", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    // sha256はペアワイズsub（':'を含む）と認証用secretを区別する
-    mockSha256.mockImplementation(async (input: string) =>
-      input.includes(":") ? PAIRWISE_SUB : "hash-abc",
-    );
+    // sha256は認証用secret等のハッシュに使用
+    mockSha256.mockResolvedValue("hash-abc");
+    // ペアワイズsubは専用関数でモック
+    mockGeneratePairwiseSub.mockResolvedValue(PAIRWISE_SUB);
     mockTimingSafeEqual.mockReturnValue(true);
     mockFindServiceByClientId.mockResolvedValue(mockService);
     mockFindUserById.mockResolvedValue(mockUser);
@@ -333,10 +336,10 @@ describe("GET /api/external/users", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    // sha256はペアワイズsub（':'を含む）と認証用secretを区別する
-    mockSha256.mockImplementation(async (input: string) =>
-      input.includes(":") ? PAIRWISE_SUB : "hash-abc",
-    );
+    // sha256は認証用secret等のハッシュに使用
+    mockSha256.mockResolvedValue("hash-abc");
+    // ペアワイズsubは専用関数でモック
+    mockGeneratePairwiseSub.mockResolvedValue(PAIRWISE_SUB);
     mockTimingSafeEqual.mockReturnValue(true);
     mockFindServiceByClientId.mockResolvedValue(mockService);
     mockListUsersAuthorizedForService.mockResolvedValue([mockUser]);

--- a/workers/id/src/routes/external.ts
+++ b/workers/id/src/routes/external.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import {
   findUserById,
   findUserIdByPairwiseSub,
-  sha256,
+  generatePairwiseSub,
   listUsersAuthorizedForService,
   countUsersAuthorizedForService,
   parsePagination,
@@ -25,14 +25,6 @@ const SCOPE_FIELDS: Record<string, (u: User) => Record<string, unknown>> = {
 };
 
 /**
- * サービス固有の不透明なユーザー識別子（ペアワイズsub）を生成する。
- * 内部IDを直接公開しないために、sha256(client_id:user_id)を使用する。
- */
-async function generatePairwiseSub(service: Service, userId: string): Promise<string> {
-  return sha256(service.client_id + ":" + userId);
-}
-
-/**
  * スコープに基づいてユーザー情報をフィルタリングし、外部向けレスポンスを構築する。
  * 内部IDの代わりにペアワイズsubを返す。
  */
@@ -41,7 +33,7 @@ async function buildUserData(
   user: User,
   allowedScopes: string[],
 ): Promise<Record<string, unknown>> {
-  const sub = await generatePairwiseSub(service, user.id);
+  const sub = await generatePairwiseSub(service.client_id, user.id);
   const data: Record<string, unknown> = { sub };
   for (const scope of allowedScopes) {
     if (scope in SCOPE_FIELDS) {

--- a/workers/id/src/routes/token.test.ts
+++ b/workers/id/src/routes/token.test.ts
@@ -12,6 +12,7 @@ vi.mock("@0g0-id/shared", () => ({
   findUserById: vi.fn(),
   revokeRefreshToken: vi.fn(),
   sha256: vi.fn(),
+  generatePairwiseSub: vi.fn(),
   timingSafeEqual: vi.fn(),
   verifyAccessToken: vi.fn(),
   // POST /api/token/ grant types で使用
@@ -42,6 +43,7 @@ import {
   findUserById,
   revokeRefreshToken,
   sha256,
+  generatePairwiseSub,
   timingSafeEqual,
   verifyAccessToken,
   findAndConsumeAuthCode,
@@ -186,6 +188,7 @@ describe("POST /api/token/introspect", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(sha256).mockResolvedValue("hashed-token");
+    vi.mocked(generatePairwiseSub).mockResolvedValue("pairwise-sub-hash");
     vi.mocked(findServiceByClientId).mockResolvedValue(mockService as never);
     vi.mocked(timingSafeEqual).mockReturnValue(true);
     vi.mocked(findRefreshTokenByHash).mockResolvedValue(mockRefreshToken as never);
@@ -374,7 +377,7 @@ describe("POST /api/token/introspect", () => {
       email: string;
     }>();
     expect(body.active).toBe(true);
-    expect(body.sub).toBe("hashed-token"); // sha256(client_id:user_id) ペアワイズsub
+    expect(body.sub).toBe("pairwise-sub-hash"); // generatePairwiseSub(client_id, user_id) ペアワイズsub
     expect(body.scope).toBe("profile email");
     expect(body.name).toBe("Test User");
     expect(body.email).toBe("test@example.com");
@@ -1082,6 +1085,7 @@ describe("POST /api/token/ — authorization_code grant", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(sha256).mockResolvedValue("hashed-value");
+    vi.mocked(generatePairwiseSub).mockResolvedValue("pairwise-sub-hash");
     vi.mocked(findServiceByClientId).mockResolvedValue(mockPublicService as never);
     vi.mocked(timingSafeEqual).mockReturnValue(true);
     vi.mocked(findAndConsumeAuthCode).mockResolvedValue(mockAuthCode as never);
@@ -1481,6 +1485,7 @@ describe("POST /api/token/ — refresh_token grant", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(sha256).mockResolvedValue("hashed-token");
+    vi.mocked(generatePairwiseSub).mockResolvedValue("pairwise-sub-hash");
     vi.mocked(findServiceByClientId).mockResolvedValue(mockPublicService as never);
     vi.mocked(timingSafeEqual).mockReturnValue(true);
     vi.mocked(findAndRevokeRefreshToken).mockResolvedValue(mockRefreshToken as never);

--- a/workers/id/src/routes/token.ts
+++ b/workers/id/src/routes/token.ts
@@ -5,6 +5,7 @@ import {
   findUserById,
   revokeRefreshToken,
   sha256,
+  generatePairwiseSub,
   verifyAccessToken,
   createLogger,
   findAndConsumeAuthCode,
@@ -461,7 +462,7 @@ async function introspectRefreshToken(
   }
   const scopeStr = refreshToken.scope ?? "";
   const scopeList = scopeStr.split(" ").filter((s: string) => s !== "openid" && s !== "");
-  const sub = await sha256(service.client_id + ":" + refreshToken.user_id);
+  const sub = await generatePairwiseSub(service.client_id, refreshToken.user_id);
   const response: Record<string, unknown> = {
     active: true,
     iss: issuer,
@@ -507,7 +508,7 @@ async function introspectJwtToken(
     // スコープ未設定の旧トークンは空文字列（RFC 7662 §2.2 - 実際に付与されたスコープのみ返す）
     const tokenScopeStr = payload.scope ?? "";
     const tokenScopes = tokenScopeStr.split(" ").filter((s: string) => s !== "openid" && s !== "");
-    const sub = await sha256(service.client_id + ":" + payload.sub);
+    const sub = await generatePairwiseSub(service.client_id, payload.sub);
     const jwtResponse: Record<string, unknown> = {
       active: true,
       iss: payload.iss,

--- a/workers/id/src/routes/userinfo.test.ts
+++ b/workers/id/src/routes/userinfo.test.ts
@@ -8,6 +8,7 @@ vi.mock("@0g0-id/shared", async (importActual) => {
     findUserById: vi.fn(),
     verifyAccessToken: vi.fn(),
     sha256: vi.fn(),
+    generatePairwiseSub: vi.fn(),
     isAccessTokenRevoked: vi.fn().mockResolvedValue(false),
   };
 });
@@ -16,7 +17,7 @@ vi.mock("../middleware/rate-limit", () => ({
   externalApiRateLimitMiddleware: vi.fn((c, next) => next()),
 }));
 
-import { findUserById, verifyAccessToken, sha256 } from "@0g0-id/shared";
+import { findUserById, verifyAccessToken, sha256, generatePairwiseSub } from "@0g0-id/shared";
 import type { TokenPayload } from "@0g0-id/shared";
 import { externalApiRateLimitMiddleware } from "../middleware/rate-limit";
 import userInfoRoutes from "./userinfo";
@@ -313,12 +314,12 @@ describe("GET /api/userinfo", () => {
         scope: "openid profile email",
         cid: "test-client-id",
       } as never);
-      vi.mocked(sha256).mockResolvedValue("pairwise-sub-hash");
+      vi.mocked(generatePairwiseSub).mockResolvedValue("pairwise-sub-hash");
       const res = await requestUserInfo(app);
       expect(res.status).toBe(200);
       const body = await res.json<Record<string, unknown>>();
       expect(body.sub).toBe("pairwise-sub-hash");
-      expect(vi.mocked(sha256)).toHaveBeenCalledWith("test-client-id:user-1");
+      expect(vi.mocked(generatePairwiseSub)).toHaveBeenCalledWith("test-client-id", "user-1");
     });
 
     it("cidなしトークン（BFFセッション）→ 内部IDをそのまま返す", async () => {

--- a/workers/id/src/routes/userinfo.ts
+++ b/workers/id/src/routes/userinfo.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from "hono";
 import type { IdpEnv, TokenPayload } from "@0g0-id/shared";
-import { findUserById, sha256 } from "@0g0-id/shared";
+import { findUserById, generatePairwiseSub } from "@0g0-id/shared";
 import { authMiddleware } from "../middleware/auth";
 import { externalApiRateLimitMiddleware } from "../middleware/rate-limit";
 
@@ -38,7 +38,7 @@ async function handleUserInfo(c: AppContext): Promise<Response> {
   const scopes = tokenUser.scope ? new Set(tokenUser.scope.split(" ")) : null;
 
   // サービストークン（cid設定済み）はペアワイズsub、BFFセッションは内部IDを返す
-  const sub = tokenUser.cid ? await sha256(tokenUser.cid + ":" + user.id) : user.id;
+  const sub = tokenUser.cid ? await generatePairwiseSub(tokenUser.cid, user.id) : user.id;
 
   const claims: Record<string, unknown> = {
     sub,

--- a/workers/id/src/utils/token-pair.test.ts
+++ b/workers/id/src/utils/token-pair.test.ts
@@ -3,11 +3,18 @@ import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 vi.mock("@0g0-id/shared", () => ({
   generateToken: vi.fn(),
   sha256: vi.fn(),
+  generatePairwiseSub: vi.fn(),
   signAccessToken: vi.fn(),
   createRefreshToken: vi.fn(),
 }));
 
-import { generateToken, sha256, signAccessToken, createRefreshToken } from "@0g0-id/shared";
+import {
+  generateToken,
+  sha256,
+  generatePairwiseSub,
+  signAccessToken,
+  createRefreshToken,
+} from "@0g0-id/shared";
 import type { IdpEnv, User } from "@0g0-id/shared";
 import {
   issueTokenPair,
@@ -93,17 +100,16 @@ describe("issueTokenPair", () => {
     );
   });
 
-  it("clientId がある場合は pairwiseSub を sha256(clientId:userId) で生成する", async () => {
-    vi.mocked(sha256)
-      .mockResolvedValueOnce("refresh-token-hash")
-      .mockResolvedValueOnce("pairwise-sub-hash");
+  it("clientId がある場合は pairwiseSub を generatePairwiseSub(clientId, userId) で生成する", async () => {
+    vi.mocked(sha256).mockResolvedValueOnce("refresh-token-hash");
+    vi.mocked(generatePairwiseSub).mockResolvedValueOnce("pairwise-sub-hash");
 
     await issueTokenPair(mockDb, mockEnv, mockUser, {
       serviceId: "service-1",
       clientId: "client-abc",
     });
 
-    expect(sha256).toHaveBeenCalledWith("client-abc:user-123");
+    expect(generatePairwiseSub).toHaveBeenCalledWith("client-abc", "user-123");
     expect(createRefreshToken).toHaveBeenCalledWith(
       mockDb,
       expect.objectContaining({ pairwiseSub: "pairwise-sub-hash" }),

--- a/workers/id/src/utils/token-pair.ts
+++ b/workers/id/src/utils/token-pair.ts
@@ -1,6 +1,7 @@
 import {
   generateToken,
   sha256,
+  generatePairwiseSub,
   signAccessToken,
   signIdToken,
   createRefreshToken,
@@ -46,7 +47,7 @@ export async function issueTokenPair(
   const expiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_MS).toISOString();
 
   // サービス連携時はペアワイズsubを事前計算して保存（外部API逆引き用）
-  const pairwiseSub = clientId ? await sha256(`${clientId}:${user.id}`) : null;
+  const pairwiseSub = clientId ? await generatePairwiseSub(clientId, user.id) : null;
 
   await createRefreshToken(db, {
     id: crypto.randomUUID(),
@@ -98,7 +99,7 @@ export async function issueIdToken(
     return undefined;
   }
 
-  const pairwiseSub = await sha256(`${service.client_id}:${user.id}`);
+  const pairwiseSub = await generatePairwiseSub(service.client_id, user.id);
   const authTime = Math.floor(Date.now() / 1000);
 
   return signIdToken(


### PR DESCRIPTION
## Summary
- `sha256(clientId:userId)` のインライン計算が6箇所に分散していたのを `packages/shared/src/lib/crypto.ts` の `generatePairwiseSub(clientId, userId)` に集約
- `external.ts`, `auth.ts`, `token-pair.ts`, `userinfo.ts`, `token.ts` の全箇所を統一
- テストのモック設定も `generatePairwiseSub` に対応

Closes #97

## Test plan
- [x] `npx vp check` パス（lint + format + typecheck）
- [x] `npx vp test run` 全2316テストパス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized pairwise OIDC subject identifier generation into a dedicated shared function, replacing inline hash computations across token exchange, introspection, userinfo, and external user endpoints. This improves code maintainability and consistency.

* **Tests**
  * Updated test mocks to reflect the new centralized subject generation function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->