### PR TITLE
機能追加: ユーザー自身によるアカウント削除UI（#100）

### DIFF
--- a/workers/user/frontend/src/lib/api.ts
+++ b/workers/user/frontend/src/lib/api.ts
@@ -20,6 +20,9 @@ export async function apiFetch<T>(
     );
     return { error: { code: "HTTP_ERROR", message: body?.error?.message ?? `HTTP ${res.status}` } };
   }
+  if (res.status === 204) {
+    return {} as T;
+  }
   const body = await res.json();
   // IdP API は { data: ... } 形式でレスポンスを返すため data をアンラップ
   if (body && typeof body === "object" && "data" in body) {

--- a/workers/user/frontend/src/pages/profile.astro
+++ b/workers/user/frontend/src/pages/profile.astro
@@ -49,10 +49,25 @@ import Base from '../layouts/Base.astro';
             <a href="/providers" class="btn btn-ghost">SNS連携</a>
           </div>
           <button id="logout-btn" class="btn btn-danger">ログアウト</button>
+          <button id="delete-account-btn" class="btn btn-danger" style="background:var(--color-danger); opacity:0.8; margin-top:0.5rem;">アカウント削除</button>
         </div>
       </div>
     </div>
   </div>
+
+  <!-- アカウント削除確認ダイアログ -->
+  <dialog id="delete-dialog" style="border:none; border-radius:12px; padding:2rem; max-width:400px; width:90%; background:var(--color-card); color:var(--color-text);">
+    <div style="display:flex; flex-direction:column; gap:1rem;">
+      <h3 style="font-weight:700; color:var(--color-danger);">アカウント削除</h3>
+      <p style="font-size:0.875rem; color:var(--color-muted);">この操作は取り消せません。すべてのデータ・セッションが削除されます。</p>
+      <p style="font-size:0.875rem;">確認のため <strong>DELETE</strong> と入力してください。</p>
+      <input id="delete-confirm-input" type="text" placeholder="DELETE" autocomplete="off" />
+      <div style="display:flex; gap:0.5rem; justify-content:flex-end;">
+        <button id="delete-cancel-btn" class="btn btn-ghost">キャンセル</button>
+        <button id="delete-execute-btn" class="btn btn-danger" disabled>削除する</button>
+      </div>
+    </div>
+  </dialog>
 </Base>
 
 <script>
@@ -133,5 +148,40 @@ import Base from '../layouts/Base.astro';
     logoutBtn.textContent = 'ログアウト中...';
     await fetch('/auth/logout', { method: 'POST', credentials: 'same-origin' });
     window.location.href = '/';
+  });
+
+  const deleteAccountBtn = document.getElementById('delete-account-btn') as HTMLButtonElement;
+  const deleteDialog = document.getElementById('delete-dialog') as HTMLDialogElement;
+  const deleteConfirmInput = document.getElementById('delete-confirm-input') as HTMLInputElement;
+  const deleteCancelBtn = document.getElementById('delete-cancel-btn') as HTMLButtonElement;
+  const deleteExecuteBtn = document.getElementById('delete-execute-btn') as HTMLButtonElement;
+
+  deleteAccountBtn.addEventListener('click', () => {
+    deleteConfirmInput.value = '';
+    deleteExecuteBtn.disabled = true;
+    deleteDialog.showModal();
+  });
+
+  deleteConfirmInput.addEventListener('input', () => {
+    deleteExecuteBtn.disabled = deleteConfirmInput.value !== 'DELETE';
+  });
+
+  deleteCancelBtn.addEventListener('click', () => {
+    deleteDialog.close();
+  });
+
+  deleteExecuteBtn.addEventListener('click', async () => {
+    deleteExecuteBtn.disabled = true;
+    deleteExecuteBtn.textContent = '削除中...';
+    const res = await apiFetch('/api/me', { method: 'DELETE' });
+    if ('error' in res) {
+      deleteExecuteBtn.disabled = false;
+      deleteExecuteBtn.textContent = '削除する';
+      showToast(res.error.message, 'error');
+      deleteDialog.close();
+    } else {
+      showToast('アカウントを削除しました', 'success');
+      setTimeout(() => { window.location.href = '/'; }, 1000);
+    }
   });
 </script>


### PR DESCRIPTION
## Summary
- profile.astro にアカウント削除ボタンと確認ダイアログを追加
- 「DELETE」と入力しないと削除を実行できない安全策を実装
- `apiFetch` で 204 レスポンス（ボディなし）を正しくハンドリングするよう修正

Closes #100

## 実装内容
- IdP の `DELETE /api/users/me` と BFF の `DELETE /api/me` は既に実装済みだったため、フロントエンドUIのみ追加
- `<dialog>` 要素による確認ダイアログで誤操作防止

## Test plan
- [x] `npx vp check` パス
- [x] 全2316テストパス
- [x] user フロントエンドビルド成功
- [ ] ブラウザでプロフィールページを開き、アカウント削除ボタンの表示を確認
- [ ] ダイアログで「DELETE」以外を入力した場合、削除ボタンが無効であることを確認
- [ ] アカウント削除後にトップページへリダイレクトされることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Account deletion is now available on the profile page. Users can delete their account through a secure confirmation dialog that requires verification before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->