### PR TITLE
テスト追加: auth-helpers.ts と provider-resolution.ts (#96)

### DIFF
--- a/workers/id/src/utils/auth-helpers.test.ts
+++ b/workers/id/src/utils/auth-helpers.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+
+vi.mock("@0g0-id/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@0g0-id/shared")>();
+  return {
+    ...actual,
+    linkProvider: vi.fn(),
+  };
+});
+
+import { linkProvider, signCookie } from "@0g0-id/shared";
+import type { User } from "@0g0-id/shared";
+import {
+  matchesExtraBffOrigins,
+  isAllowedRedirectTo,
+  isBffOrigin,
+  parseStateFromCookie,
+  handleProviderLink,
+} from "./auth-helpers";
+
+const mockLinkProvider = vi.mocked(linkProvider);
+const mockDb = {} as D1Database;
+
+const mockUser: User = {
+  id: "user-1",
+  google_sub: "google-123",
+  line_sub: null,
+  twitch_sub: null,
+  github_sub: null,
+  x_sub: null,
+  email: "test@example.com",
+  email_verified: 1,
+  name: "Test User",
+  picture: null,
+  phone: null,
+  address: null,
+  role: "user",
+  banned_at: null,
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+// ============================================================
+// matchesExtraBffOrigins
+// ============================================================
+describe("matchesExtraBffOrigins", () => {
+  it("カンマ区切りリストのオリジンと一致する場合 true を返す", () => {
+    const url = new URL("https://app.example.com/callback");
+    expect(matchesExtraBffOrigins(url, "https://app.example.com,https://other.example.com")).toBe(
+      true,
+    );
+  });
+
+  it("リスト内の2番目のオリジンとも一致する", () => {
+    const url = new URL("https://other.example.com/path");
+    expect(matchesExtraBffOrigins(url, "https://app.example.com,https://other.example.com")).toBe(
+      true,
+    );
+  });
+
+  it("リストのどのオリジンとも一致しない場合 false を返す", () => {
+    const url = new URL("https://evil.com/callback");
+    expect(matchesExtraBffOrigins(url, "https://app.example.com,https://other.example.com")).toBe(
+      false,
+    );
+  });
+
+  it("extraBffOrigins が undefined の場合 false を返す", () => {
+    const url = new URL("https://app.example.com/callback");
+    expect(matchesExtraBffOrigins(url, undefined)).toBe(false);
+  });
+
+  it("extraBffOrigins が空文字列の場合 false を返す", () => {
+    const url = new URL("https://app.example.com/callback");
+    expect(matchesExtraBffOrigins(url, "")).toBe(false);
+  });
+
+  it("リスト内の不正なURLは無視される", () => {
+    const url = new URL("https://app.example.com/callback");
+    expect(matchesExtraBffOrigins(url, "not-a-url,https://app.example.com")).toBe(true);
+  });
+
+  it("リスト内の全てが不正なURLの場合 false を返す", () => {
+    const url = new URL("https://app.example.com/callback");
+    expect(matchesExtraBffOrigins(url, "not-a-url,also-bad")).toBe(false);
+  });
+
+  it("スペースを含むカンマ区切りを正しくトリムする", () => {
+    const url = new URL("https://app.example.com/callback");
+    expect(matchesExtraBffOrigins(url, " https://app.example.com , https://other.com ")).toBe(true);
+  });
+});
+
+// ============================================================
+// isAllowedRedirectTo
+// ============================================================
+describe("isAllowedRedirectTo", () => {
+  const idpOrigin = "https://id.0g0.xyz";
+
+  it("同一登録可能ドメインのサブドメインを許可する（user.0g0.xyz）", () => {
+    expect(isAllowedRedirectTo("https://user.0g0.xyz/callback", idpOrigin)).toBe(true);
+  });
+
+  it("同一登録可能ドメインのサブドメインを許可する（admin.0g0.xyz）", () => {
+    expect(isAllowedRedirectTo("https://admin.0g0.xyz/callback", idpOrigin)).toBe(true);
+  });
+
+  it("登録可能ドメイン自体を許可する（0g0.xyz）", () => {
+    expect(isAllowedRedirectTo("https://0g0.xyz/callback", idpOrigin)).toBe(true);
+  });
+
+  it("異なる登録可能ドメインを拒否する（evil.com）", () => {
+    expect(isAllowedRedirectTo("https://evil.com/callback", idpOrigin)).toBe(false);
+  });
+
+  it("PSL private ドメイン: evil.github.io を拒否する（github.io は PSL private suffix）", () => {
+    const githubIdpOrigin = "https://myapp.github.io";
+    expect(isAllowedRedirectTo("https://evil.github.io/callback", githubIdpOrigin)).toBe(false);
+  });
+
+  it("IPアドレスの IDP_ORIGIN では親ドメイン導出をスキップする", () => {
+    const ipIdpOrigin = "https://192.168.1.1";
+    // IPアドレスの場合、ドメインマッチはスキップされるので EXTRA_BFF_ORIGINS がないと false
+    expect(isAllowedRedirectTo("https://192.168.1.2/callback", ipIdpOrigin)).toBe(false);
+  });
+
+  it("IPアドレスの IDP_ORIGIN でも EXTRA_BFF_ORIGINS で許可できる", () => {
+    const ipIdpOrigin = "https://192.168.1.1";
+    expect(
+      isAllowedRedirectTo("https://192.168.1.2/callback", ipIdpOrigin, "https://192.168.1.2"),
+    ).toBe(true);
+  });
+
+  it("HTTP を拒否する（HTTPS必須）", () => {
+    expect(isAllowedRedirectTo("http://user.0g0.xyz/callback", idpOrigin)).toBe(false);
+  });
+
+  it("不正なURLを拒否する", () => {
+    expect(isAllowedRedirectTo("not-a-url", idpOrigin)).toBe(false);
+  });
+
+  it("空文字列を拒否する", () => {
+    expect(isAllowedRedirectTo("", idpOrigin)).toBe(false);
+  });
+
+  it("EXTRA_BFF_ORIGINS でマッチする外部ドメインを許可する", () => {
+    expect(
+      isAllowedRedirectTo(
+        "https://external.example.com/callback",
+        idpOrigin,
+        "https://external.example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("EXTRA_BFF_ORIGINS にもドメインにもマッチしない場合は拒否する", () => {
+    expect(
+      isAllowedRedirectTo("https://evil.com/callback", idpOrigin, "https://external.example.com"),
+    ).toBe(false);
+  });
+});
+
+// ============================================================
+// isBffOrigin
+// ============================================================
+describe("isBffOrigin", () => {
+  const userOrigin = "https://user.0g0.xyz";
+  const adminOrigin = "https://admin.0g0.xyz";
+
+  it("USER_ORIGIN と完全一致する場合 true を返す", () => {
+    expect(isBffOrigin("https://user.0g0.xyz/callback", userOrigin, adminOrigin)).toBe(true);
+  });
+
+  it("ADMIN_ORIGIN と完全一致する場合 true を返す", () => {
+    expect(isBffOrigin("https://admin.0g0.xyz/callback", userOrigin, adminOrigin)).toBe(true);
+  });
+
+  it("どちらのオリジンとも一致しない場合 false を返す", () => {
+    expect(isBffOrigin("https://other.0g0.xyz/callback", userOrigin, adminOrigin)).toBe(false);
+  });
+
+  it("HTTP を拒否する", () => {
+    expect(isBffOrigin("http://user.0g0.xyz/callback", userOrigin, adminOrigin)).toBe(false);
+  });
+
+  it("不正なURLを拒否する", () => {
+    expect(isBffOrigin("not-a-url", userOrigin, adminOrigin)).toBe(false);
+  });
+
+  it("EXTRA_BFF_ORIGINS でマッチする場合 true を返す", () => {
+    expect(
+      isBffOrigin(
+        "https://external.example.com/callback",
+        userOrigin,
+        adminOrigin,
+        "https://external.example.com",
+      ),
+    ).toBe(true);
+  });
+
+  it("EXTRA_BFF_ORIGINS にもオリジンにもマッチしない場合 false を返す", () => {
+    expect(
+      isBffOrigin(
+        "https://evil.com/callback",
+        userOrigin,
+        adminOrigin,
+        "https://external.example.com",
+      ),
+    ).toBe(false);
+  });
+});
+
+// ============================================================
+// parseStateFromCookie
+// ============================================================
+describe("parseStateFromCookie", () => {
+  const secret = "test-secret-key-for-cookie-signing";
+
+  it("正しく署名されたCookieから OAuthStateCookieData を返す", async () => {
+    const stateData = {
+      idState: "state-123",
+      redirectTo: "https://user.0g0.xyz/callback",
+      bffState: "bff-state-456",
+      provider: "google",
+    };
+    const signed = await signCookie(JSON.stringify(stateData), secret);
+    const result = await parseStateFromCookie(signed, secret);
+
+    expect(result).not.toBeNull();
+    expect(result!.idState).toBe("state-123");
+    expect(result!.redirectTo).toBe("https://user.0g0.xyz/callback");
+    expect(result!.bffState).toBe("bff-state-456");
+  });
+
+  it("改ざんされたCookieの場合 null を返す", async () => {
+    const stateData = {
+      idState: "state-123",
+      redirectTo: "https://user.0g0.xyz/callback",
+      bffState: "bff-state-456",
+      provider: "google",
+    };
+    const signed = await signCookie(JSON.stringify(stateData), secret);
+    const tampered = signed + "tampered";
+    const result = await parseStateFromCookie(tampered, secret);
+
+    expect(result).toBeNull();
+  });
+
+  it("異なるシークレットで署名されたCookieの場合 null を返す", async () => {
+    const stateData = {
+      idState: "state-123",
+      redirectTo: "https://user.0g0.xyz/callback",
+      bffState: "bff-state-456",
+      provider: "google",
+    };
+    const signed = await signCookie(JSON.stringify(stateData), "different-secret");
+    const result = await parseStateFromCookie(signed, secret);
+
+    expect(result).toBeNull();
+  });
+
+  it("署名は正しいがJSONが不正な場合 null を返す", async () => {
+    const signed = await signCookie("not-valid-json{{{", secret);
+    const result = await parseStateFromCookie(signed, secret);
+
+    expect(result).toBeNull();
+  });
+
+  it("必須フィールド idState が欠けている場合 null を返す", async () => {
+    const incomplete = { redirectTo: "https://example.com", bffState: "bff" };
+    const signed = await signCookie(JSON.stringify(incomplete), secret);
+    const result = await parseStateFromCookie(signed, secret);
+
+    expect(result).toBeNull();
+  });
+
+  it("必須フィールド redirectTo が欠けている場合 null を返す", async () => {
+    const incomplete = { idState: "state", bffState: "bff" };
+    const signed = await signCookie(JSON.stringify(incomplete), secret);
+    const result = await parseStateFromCookie(signed, secret);
+
+    expect(result).toBeNull();
+  });
+
+  it("必須フィールド bffState が欠けている場合 null を返す", async () => {
+    const incomplete = { idState: "state", redirectTo: "https://example.com" };
+    const signed = await signCookie(JSON.stringify(incomplete), secret);
+    const result = await parseStateFromCookie(signed, secret);
+
+    expect(result).toBeNull();
+  });
+
+  it("オプションフィールド（linkUserId, serviceId等）を含むデータを正しくパースする", async () => {
+    const stateData = {
+      idState: "state-123",
+      redirectTo: "https://user.0g0.xyz/callback",
+      bffState: "bff-state-456",
+      provider: "google",
+      linkUserId: "user-1",
+      serviceId: "service-1",
+      nonce: "nonce-789",
+    };
+    const signed = await signCookie(JSON.stringify(stateData), secret);
+    const result = await parseStateFromCookie(signed, secret);
+
+    expect(result).not.toBeNull();
+    expect(result!.linkUserId).toBe("user-1");
+    expect(result!.serviceId).toBe("service-1");
+    expect(result!.nonce).toBe("nonce-789");
+  });
+});
+
+// ============================================================
+// handleProviderLink
+// ============================================================
+describe("handleProviderLink", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("成功時に { ok: true, user } を返す", async () => {
+    mockLinkProvider.mockResolvedValue(mockUser);
+
+    const result = await handleProviderLink(mockDb, "user-1", "google", "google-sub-123");
+
+    expect(result).toEqual({ ok: true, user: mockUser });
+    expect(mockLinkProvider).toHaveBeenCalledWith(mockDb, "user-1", "google", "google-sub-123");
+  });
+
+  it("PROVIDER_ALREADY_LINKED エラーの場合 { ok: false } を返す", async () => {
+    mockLinkProvider.mockRejectedValue(new Error("PROVIDER_ALREADY_LINKED"));
+
+    const result = await handleProviderLink(mockDb, "user-1", "google", "google-sub-123");
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("PROVIDER_ALREADY_LINKED 以外のエラーは再スローする", async () => {
+    const otherError = new Error("Database connection failed");
+    mockLinkProvider.mockRejectedValue(otherError);
+
+    await expect(handleProviderLink(mockDb, "user-1", "google", "google-sub-123")).rejects.toThrow(
+      "Database connection failed",
+    );
+  });
+
+  it("Error インスタンスでないエラーは再スローする", async () => {
+    mockLinkProvider.mockRejectedValue("string error");
+
+    await expect(handleProviderLink(mockDb, "user-1", "google", "google-sub-123")).rejects.toBe(
+      "string error",
+    );
+  });
+});

--- a/workers/id/src/utils/provider-resolution.test.ts
+++ b/workers/id/src/utils/provider-resolution.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+
+vi.mock("@0g0-id/shared", () => ({
+  exchangeGoogleCode: vi.fn(),
+  fetchGoogleUserInfo: vi.fn(),
+  exchangeLineCode: vi.fn(),
+  fetchLineUserInfo: vi.fn(),
+  exchangeTwitchCode: vi.fn(),
+  fetchTwitchUserInfo: vi.fn(),
+  exchangeGithubCode: vi.fn(),
+  fetchGithubUserInfo: vi.fn(),
+  fetchGithubPrimaryEmail: vi.fn(),
+  exchangeXCode: vi.fn(),
+  fetchXUserInfo: vi.fn(),
+  upsertUser: vi.fn(),
+  upsertLineUser: vi.fn(),
+  upsertTwitchUser: vi.fn(),
+  upsertGithubUser: vi.fn(),
+  upsertXUser: vi.fn(),
+  createLogger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
+}));
+
+import {
+  exchangeGoogleCode,
+  fetchGoogleUserInfo,
+  exchangeLineCode,
+  fetchLineUserInfo,
+  exchangeTwitchCode,
+  fetchTwitchUserInfo,
+  exchangeGithubCode,
+  fetchGithubUserInfo,
+  fetchGithubPrimaryEmail,
+  exchangeXCode,
+  fetchXUserInfo,
+} from "@0g0-id/shared";
+import type { IdpEnv, TokenPayload } from "@0g0-id/shared";
+import { Hono } from "hono";
+import { resolveProvider } from "./provider-resolution";
+import type { OAuthProvider } from "@0g0-id/shared";
+
+type Variables = { user: TokenPayload };
+
+const mockEnv: Partial<IdpEnv> = {
+  GOOGLE_CLIENT_ID: "google-id",
+  GOOGLE_CLIENT_SECRET: "google-secret",
+  LINE_CLIENT_ID: "line-id",
+  LINE_CLIENT_SECRET: "line-secret",
+  TWITCH_CLIENT_ID: "twitch-id",
+  TWITCH_CLIENT_SECRET: "twitch-secret",
+  GITHUB_CLIENT_ID: "github-id",
+  GITHUB_CLIENT_SECRET: "github-secret",
+  X_CLIENT_ID: "x-id",
+  X_CLIENT_SECRET: "x-secret",
+};
+
+function createApp(provider: OAuthProvider): Hono<{ Bindings: IdpEnv; Variables: Variables }> {
+  const app = new Hono<{ Bindings: IdpEnv; Variables: Variables }>();
+  app.post("/test", async (c) => {
+    const result = await resolveProvider(c, provider, "code", "verifier", "https://callback");
+    if (result.ok) {
+      return c.json({ ok: true, sub: result.sub });
+    }
+    return result.response;
+  });
+  return app;
+}
+
+async function callProvider(provider: OAuthProvider): Promise<Response> {
+  const app = createApp(provider);
+  return app.request("/test", { method: "POST" }, mockEnv as IdpEnv);
+}
+
+// ---------- Google ----------
+
+describe("resolveProvider - Google", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常: email_verified=true → ok=true", async () => {
+    vi.mocked(exchangeGoogleCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    vi.mocked(fetchGoogleUserInfo).mockResolvedValue({
+      sub: "google-sub-1",
+      email: "user@example.com",
+      email_verified: true,
+      name: "Test User",
+      picture: "https://pic.example.com/a.jpg",
+    });
+
+    const res = await callProvider("google");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "google-sub-1" });
+  });
+
+  it("email_verified=false → UNVERIFIED_EMAIL エラー", async () => {
+    vi.mocked(exchangeGoogleCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    vi.mocked(fetchGoogleUserInfo).mockResolvedValue({
+      sub: "google-sub-1",
+      email: "user@example.com",
+      email_verified: false,
+      name: "Test User",
+    });
+
+    const res = await callProvider("google");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("UNVERIFIED_EMAIL");
+  });
+
+  it("exchangeGoogleCode が例外 → ok=false", async () => {
+    vi.mocked(exchangeGoogleCode).mockRejectedValue(new Error("exchange failed"));
+
+    const res = await callProvider("google");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("OAUTH_ERROR");
+  });
+
+  it("fetchGoogleUserInfo が例外 → ok=false", async () => {
+    vi.mocked(exchangeGoogleCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    vi.mocked(fetchGoogleUserInfo).mockRejectedValue(new Error("fetch failed"));
+
+    const res = await callProvider("google");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("OAUTH_ERROR");
+  });
+});
+
+// ---------- LINE ----------
+
+describe("resolveProvider - LINE", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常: email あり → ok=true", async () => {
+    vi.mocked(exchangeLineCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: "openid profile email",
+    });
+    vi.mocked(fetchLineUserInfo).mockResolvedValue({
+      sub: "line-sub-1",
+      email: "line@example.com",
+      name: "LINE User",
+      picture: "https://pic.example.com/line.jpg",
+    });
+
+    const res = await callProvider("line");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "line-sub-1" });
+  });
+
+  it("email なし → placeholder email で ok=true", async () => {
+    vi.mocked(exchangeLineCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "Bearer",
+      expires_in: 3600,
+      scope: "openid profile email",
+    });
+    vi.mocked(fetchLineUserInfo).mockResolvedValue({
+      sub: "line-sub-2",
+      email: undefined,
+      name: "LINE User",
+    });
+
+    const res = await callProvider("line");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "line-sub-2" });
+  });
+});
+
+// ---------- Twitch ----------
+
+describe("resolveProvider - Twitch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常: email 検証済み → ok=true", async () => {
+    vi.mocked(exchangeTwitchCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "bearer",
+      expires_in: 3600,
+      scope: ["openid", "user:read:email"],
+    });
+    vi.mocked(fetchTwitchUserInfo).mockResolvedValue({
+      sub: "twitch-sub-1",
+      email: "twitch@example.com",
+      email_verified: true,
+      preferred_username: "TwitchUser",
+      picture: "https://pic.example.com/twitch.jpg",
+    });
+
+    const res = await callProvider("twitch");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "twitch-sub-1" });
+  });
+
+  it("email 未検証 → UNVERIFIED_EMAIL エラー", async () => {
+    vi.mocked(exchangeTwitchCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "bearer",
+      expires_in: 3600,
+      scope: ["openid", "user:read:email"],
+    });
+    vi.mocked(fetchTwitchUserInfo).mockResolvedValue({
+      sub: "twitch-sub-1",
+      email: "twitch@example.com",
+      email_verified: false,
+      preferred_username: "TwitchUser",
+    });
+
+    const res = await callProvider("twitch");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("UNVERIFIED_EMAIL");
+  });
+
+  it("email なし → placeholder で ok=true（UNVERIFIED_EMAIL にならない）", async () => {
+    vi.mocked(exchangeTwitchCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "bearer",
+      expires_in: 3600,
+      scope: ["openid", "user:read:email"],
+    });
+    vi.mocked(fetchTwitchUserInfo).mockResolvedValue({
+      sub: "twitch-sub-2",
+      preferred_username: "TwitchUser",
+    });
+
+    const res = await callProvider("twitch");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "twitch-sub-2" });
+  });
+});
+
+// ---------- GitHub ----------
+
+describe("resolveProvider - GitHub", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常 → ok=true, sub = String(githubUser.id)", async () => {
+    vi.mocked(exchangeGithubCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "bearer",
+      scope: "read:user,user:email",
+    });
+    vi.mocked(fetchGithubUserInfo).mockResolvedValue({
+      id: 12345,
+      login: "ghuser",
+      name: "GitHub User",
+      email: null,
+      avatar_url: "https://avatars.example.com/12345",
+    });
+    vi.mocked(fetchGithubPrimaryEmail).mockResolvedValue("gh@example.com");
+
+    const res = await callProvider("github");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "12345" });
+  });
+
+  it("fetchGithubPrimaryEmail が null → placeholder email で ok=true", async () => {
+    vi.mocked(exchangeGithubCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "bearer",
+      scope: "read:user,user:email",
+    });
+    vi.mocked(fetchGithubUserInfo).mockResolvedValue({
+      id: 99999,
+      login: "ghuser2",
+      name: null,
+      email: null,
+      avatar_url: "https://avatars.example.com/99999",
+    });
+    vi.mocked(fetchGithubPrimaryEmail).mockResolvedValue(null);
+
+    const res = await callProvider("github");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "99999" });
+  });
+
+  it("fetchGithubPrimaryEmail が例外 → ok=false", async () => {
+    vi.mocked(exchangeGithubCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "bearer",
+      scope: "read:user,user:email",
+    });
+    vi.mocked(fetchGithubUserInfo).mockResolvedValue({
+      id: 12345,
+      login: "ghuser",
+      name: "GitHub User",
+      email: null,
+      avatar_url: "https://avatars.example.com/12345",
+    });
+    vi.mocked(fetchGithubPrimaryEmail).mockRejectedValue(new Error("email fetch failed"));
+
+    const res = await callProvider("github");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("OAUTH_ERROR");
+  });
+});
+
+// ---------- X ----------
+
+describe("resolveProvider - X", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常 → ok=true, 常に placeholder email", async () => {
+    vi.mocked(exchangeXCode).mockResolvedValue({
+      access_token: "at",
+      token_type: "bearer",
+      scope: "tweet.read users.read offline.access",
+    });
+    vi.mocked(fetchXUserInfo).mockResolvedValue({
+      id: "x-sub-1",
+      username: "xuser",
+      name: "X User",
+      profile_image_url: "https://pbs.example.com/x.jpg",
+    });
+
+    const res = await callProvider("x");
+    expect(res.status).toBe(200);
+    const body = await res.json<Record<string, unknown>>();
+    expect(body).toEqual({ ok: true, sub: "x-sub-1" });
+  });
+});


### PR DESCRIPTION
## Summary
- `auth-helpers.test.ts`: matchesExtraBffOrigins, isAllowedRedirectTo, isBffOrigin, parseStateFromCookie, handleProviderLink の39テスト
- `provider-resolution.test.ts`: Google/LINE/Twitch/GitHub/X 全5プロバイダーのresolveProvider テスト（正常系・エラー系）

Closes #96

## Test plan
- [x] `npx vp check` 通過（lint, format, typecheck）
- [x] `npx vp test run` 全2368テスト通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication helper functions and OAuth provider resolution across multiple providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->