### PR TITLE
リファクタリング: UUID バリデーションミドルウェアを共通パッケージに抽出 (#111)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export * from "./lib/logger";
 export * from "./lib/providers";
 export * from "./lib/parse-body";
 export * from "./middleware/body-limit";
+export * from "./middleware/uuid-param";
 export * from "./lib/sql";
 export * from "./lib/redirect-uri";
 export * from "./lib/validation";

--- a/packages/shared/src/middleware/uuid-param.test.ts
+++ b/packages/shared/src/middleware/uuid-param.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vite-plus/test";
+import { Hono } from "hono";
+import { uuidParamMiddleware } from "./uuid-param";
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+function buildApp(allowValues?: readonly string[]) {
+  const app = new Hono();
+  app.use("/:id", uuidParamMiddleware("id", { allowValues }));
+  app.use("/:id/*", uuidParamMiddleware("id", { allowValues }));
+  app.get("/:id", (c) => c.json({ id: c.req.param("id") }));
+  app.get("/:id/detail", (c) => c.json({ id: c.req.param("id") }));
+  return app;
+}
+
+describe("uuidParamMiddleware", () => {
+  it("有効なUUIDは通過する", async () => {
+    const app = buildApp();
+    const res = await app.request(`https://example.com/${VALID_UUID}`);
+    expect(res.status).toBe(200);
+    const json = await res.json<{ id: string }>();
+    expect(json.id).toBe(VALID_UUID);
+  });
+
+  it("無効なIDは400を返す", async () => {
+    const app = buildApp();
+    const res = await app.request("https://example.com/not-a-uuid");
+    expect(res.status).toBe(400);
+    const json = await res.json<{ error: { code: string; message: string } }>();
+    expect(json.error.code).toBe("BAD_REQUEST");
+    expect(json.error.message).toBe("Invalid id ID format");
+  });
+
+  it("サブパスでも無効なIDは400を返す", async () => {
+    const app = buildApp();
+    const res = await app.request("https://example.com/not-a-uuid/detail");
+    expect(res.status).toBe(400);
+  });
+
+  it("allowValuesに含まれる値は通過する", async () => {
+    const app = buildApp(["me"]);
+    const res = await app.request("https://example.com/me");
+    expect(res.status).toBe(200);
+    const json = await res.json<{ id: string }>();
+    expect(json.id).toBe("me");
+  });
+
+  it("allowValuesに含まれない非UUID値は400を返す", async () => {
+    const app = buildApp(["me"]);
+    const res = await app.request("https://example.com/you");
+    expect(res.status).toBe(400);
+  });
+
+  it("大文字UUIDも通過する", async () => {
+    const app = buildApp();
+    const res = await app.request(`https://example.com/${VALID_UUID.toUpperCase()}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/shared/src/middleware/uuid-param.ts
+++ b/packages/shared/src/middleware/uuid-param.ts
@@ -1,0 +1,25 @@
+import type { MiddlewareHandler } from "hono";
+import { UUID_RE } from "../lib/validation";
+
+/**
+ * UUID パラメータバリデーションミドルウェアを生成するファクトリ関数。
+ * 指定パラメータが UUID 形式でなければ 400 を返す。
+ *
+ * @param paramName - 検証対象のパスパラメータ名（デフォルト: "id"）
+ * @param options.allowValues - UUID 以外に許可する値（例: ["me"]）
+ * @param options.label - エラーメッセージに使うラベル（例: "user ID"）
+ */
+export function uuidParamMiddleware(
+  paramName = "id",
+  options: { allowValues?: readonly string[]; label?: string } = {},
+): MiddlewareHandler {
+  const { allowValues = [], label = `${paramName} ID` } = options;
+  return async (c, next) => {
+    const value = c.req.param(paramName) ?? "";
+    if (allowValues.includes(value)) return next();
+    if (!UUID_RE.test(value)) {
+      return c.json({ error: { code: "BAD_REQUEST", message: `Invalid ${label} format` } }, 400);
+    }
+    await next();
+  };
+}

--- a/workers/admin/src/index.test.ts
+++ b/workers/admin/src/index.test.ts
@@ -18,6 +18,7 @@ vi.mock("@0g0-id/shared", () => ({
     .fn()
     .mockReturnValue({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   validateBffEnv: vi.fn(),
+  uuidParamMiddleware: () => async (_c: unknown, next: () => Promise<void>) => next(),
 }));
 
 vi.mock("./middleware/csrf", () => ({

--- a/workers/admin/src/routes/services.ts
+++ b/workers/admin/src/routes/services.ts
@@ -6,6 +6,7 @@ import {
   proxyMutate,
   proxyResponse,
   UUID_RE,
+  uuidParamMiddleware,
 } from "@0g0-id/shared";
 import type { BffEnv } from "@0g0-id/shared";
 import { SESSION_COOKIE } from "./auth";
@@ -13,18 +14,8 @@ import { SESSION_COOKIE } from "./auth";
 const app = new Hono<{ Bindings: BffEnv }>();
 
 // サービスID形式検証ミドルウェア（:id パラメータを持つすべてのルートに適用）
-app.use("/:id", async (c, next) => {
-  if (!UUID_RE.test(c.req.param("id"))) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid service ID format" } }, 400);
-  }
-  await next();
-});
-app.use("/:id/*", async (c, next) => {
-  if (!UUID_RE.test(c.req.param("id"))) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid service ID format" } }, 400);
-  }
-  await next();
-});
+app.use("/:id", uuidParamMiddleware("id", { label: "service ID" }));
+app.use("/:id/*", uuidParamMiddleware("id", { label: "service ID" }));
 
 // GET /api/services
 app.get("/", async (c) => {

--- a/workers/admin/src/routes/users.ts
+++ b/workers/admin/src/routes/users.ts
@@ -8,6 +8,7 @@ import {
   proxyMutate,
   proxyResponse,
   UUID_RE,
+  uuidParamMiddleware,
 } from "@0g0-id/shared";
 import type { BffEnv } from "@0g0-id/shared";
 import { SESSION_COOKIE } from "./auth";
@@ -15,18 +16,8 @@ import { SESSION_COOKIE } from "./auth";
 const app = new Hono<{ Bindings: BffEnv }>();
 
 // ユーザーID形式検証ミドルウェア（:id パラメータを持つすべてのルートに適用）
-app.use("/:id", async (c, next) => {
-  if (!UUID_RE.test(c.req.param("id"))) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid user ID format" } }, 400);
-  }
-  await next();
-});
-app.use("/:id/*", async (c, next) => {
-  if (!UUID_RE.test(c.req.param("id"))) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid user ID format" } }, 400);
-  }
-  await next();
-});
+app.use("/:id", uuidParamMiddleware("id", { label: "user ID" }));
+app.use("/:id/*", uuidParamMiddleware("id", { label: "user ID" }));
 
 // GET /api/users
 app.get("/", async (c) => {

--- a/workers/id/src/index.test.ts
+++ b/workers/id/src/index.test.ts
@@ -44,6 +44,7 @@ vi.mock("@0g0-id/shared", () => ({
   cleanupExpiredMcpSessions: vi.fn().mockResolvedValue(0),
   cleanupExpiredRevokedAccessTokens: vi.fn().mockResolvedValue(0),
   deleteExpiredRefreshTokens: vi.fn().mockResolvedValue(0),
+  uuidParamMiddleware: () => async (_c: unknown, next: () => Promise<void>) => next(),
 }));
 
 import type { IdpEnv } from "@0g0-id/shared";

--- a/workers/id/src/routes/services.test.ts
+++ b/workers/id/src/routes/services.test.ts
@@ -33,6 +33,8 @@ vi.mock("@0g0-id/shared", async (importOriginal) => {
     countServices: vi.fn(),
     createAdminAuditLog: vi.fn(),
     UUID_RE: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    uuidParamMiddleware: (await importOriginal<typeof import("@0g0-id/shared")>())
+      .uuidParamMiddleware,
     parsePagination: (
       query: { limit?: string; offset?: string },
       options: { defaultLimit: number; maxLimit: number } = { defaultLimit: 20, maxLimit: 100 },

--- a/workers/id/src/routes/services.ts
+++ b/workers/id/src/routes/services.ts
@@ -25,6 +25,7 @@ import {
   createAdminAuditLog,
   parsePagination,
   UUID_RE,
+  uuidParamMiddleware,
   createLogger,
 } from "@0g0-id/shared";
 import type {
@@ -93,18 +94,8 @@ const TransferOwnerSchema = z.object({
 const app = new Hono<{ Bindings: IdpEnv; Variables: Variables }>();
 
 // サービスID形式検証ミドルウェア（:id パラメータを持つすべてのルートに適用）
-app.use("/:id", async (c, next) => {
-  if (!UUID_RE.test(c.req.param("id"))) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid service ID format" } }, 400);
-  }
-  await next();
-});
-app.use("/:id/*", async (c, next) => {
-  if (!UUID_RE.test(c.req.param("id"))) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid service ID format" } }, 400);
-  }
-  await next();
-});
+app.use("/:id", uuidParamMiddleware("id", { label: "service ID" }));
+app.use("/:id/*", uuidParamMiddleware("id", { label: "service ID" }));
 
 // GET /api/services
 app.get("/", authMiddleware, adminMiddleware, async (c) => {

--- a/workers/id/src/routes/users.test.ts
+++ b/workers/id/src/routes/users.test.ts
@@ -33,6 +33,8 @@ vi.mock("@0g0-id/shared", async (importOriginal) => {
     unbanUser: vi.fn(),
     createAdminAuditLog: vi.fn(),
     UUID_RE: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    uuidParamMiddleware: (await importOriginal<typeof import("@0g0-id/shared")>())
+      .uuidParamMiddleware,
     isValidProvider: (value: string) => ["google", "line", "twitch", "github", "x"].includes(value),
     parseDays: (
       daysParam: string | undefined,

--- a/workers/id/src/routes/users.ts
+++ b/workers/id/src/routes/users.ts
@@ -28,6 +28,7 @@ import {
   parsePagination,
   isValidProvider,
   UUID_RE,
+  uuidParamMiddleware,
   type OAuthProvider,
   type UserFilter,
   createLogger,
@@ -149,22 +150,8 @@ async function performUserDeletion(
 const app = new Hono<{ Bindings: IdpEnv; Variables: Variables }>();
 
 // ユーザーID形式検証ミドルウェア（:id パラメータを持つすべてのルートに適用、/me は除外）
-app.use("/:id", async (c, next) => {
-  const id = c.req.param("id");
-  if (id === "me") return next();
-  if (!UUID_RE.test(id)) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid user ID format" } }, 400);
-  }
-  await next();
-});
-app.use("/:id/*", async (c, next) => {
-  const id = c.req.param("id");
-  if (id === "me") return next();
-  if (!UUID_RE.test(id)) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid user ID format" } }, 400);
-  }
-  await next();
-});
+app.use("/:id", uuidParamMiddleware("id", { allowValues: ["me"], label: "user ID" }));
+app.use("/:id/*", uuidParamMiddleware("id", { allowValues: ["me"], label: "user ID" }));
 
 // GET /api/users/me
 app.get(


### PR DESCRIPTION
## Summary
- `packages/shared/src/middleware/uuid-param.ts` に `uuidParamMiddleware` ファクトリ関数を新規作成
- 4ファイル（admin/users, admin/services, id/users, id/services）で重複していたUUIDパラメータ検証ミドルウェアを共通化
- `allowValues` オプション（`/me` などの例外値）と `label` オプション（エラーメッセージのカスタマイズ）をサポート

Closes #111

## Test plan
- [x] `uuidParamMiddleware` の単体テスト追加（6ケース）
- [x] 既存テスト全件パス（2376テスト）
- [x] `npx vp check` パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate UUID parameter validation logic across route handlers into a shared, reusable middleware component to reduce code duplication.

* **Tests**
  * Added comprehensive test coverage for UUID parameter validation middleware, including valid/invalid UUID formats and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->