### PR TITLE
リファクタリング: BFF 認証ルート（admin/user）の共通化

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,6 +13,7 @@ export * from "./lib/twitch";
 export * from "./lib/github";
 export * from "./lib/x";
 export * from "./lib/bff";
+export * from "./lib/bff-auth-factory";
 export * from "./lib/pagination";
 export * from "./lib/logger";
 export * from "./lib/providers";

--- a/packages/shared/src/lib/bff-auth-factory.ts
+++ b/packages/shared/src/lib/bff-auth-factory.ts
@@ -1,0 +1,124 @@
+import { Hono } from "hono";
+import { getCookie, deleteCookie } from "hono/cookie";
+import type { BffEnv } from "../types";
+import { generateToken } from "./crypto";
+import { parseSession, setSessionCookie, exchangeCodeAtIdp, revokeTokenAtIdp } from "./bff";
+import { setOAuthStateCookie, verifyAndConsumeOAuthState } from "./bff";
+import { createLogger } from "./logger";
+import type { ExchangeResult } from "./bff";
+
+/** ファクトリに渡す設定 */
+export interface BffAuthConfig {
+  /** セッションCookie名（例: "__Host-admin-session"） */
+  sessionCookieName: string;
+  /** OAuth state Cookie名（例: "__Host-admin-oauth-state"） */
+  stateCookieName: string;
+  /** ロガー名（例: "admin-auth"） */
+  loggerName: string;
+  /** ログイン成功後のリダイレクト先（例: "/dashboard"） */
+  successRedirect: string;
+  /** login URLに追加するパラメータを返す。Responseを返すとそこで中断（バリデーションエラー等） */
+  loginParams?: (c: {
+    req: { query: (key: string) => string | undefined };
+    redirect: (url: string) => Response;
+  }) => Record<string, string> | Response;
+  /** callback時の追加チェック。リダイレクトResponseを返すとそこで中断 */
+  onCallbackCheck?: (
+    c: { redirect: (url: string) => Response; env: BffEnv },
+    result: ExchangeResult,
+  ) => Promise<Response | null>;
+}
+
+/** BFF認証ルート（login / callback / logout）を生成するファクトリ */
+export function createBffAuthRoutes(config: BffAuthConfig) {
+  const app = new Hono<{ Bindings: BffEnv }>();
+  const logger = createLogger(config.loggerName);
+
+  // GET /auth/login
+  app.get("/login", async (c) => {
+    const state = generateToken(16);
+    const callbackUrl = `${c.env.SELF_ORIGIN}/auth/callback`;
+
+    setOAuthStateCookie(c, config.stateCookieName, state);
+
+    const loginUrl = new URL(`${c.env.IDP_ORIGIN}/auth/login`);
+    loginUrl.searchParams.set("redirect_to", callbackUrl);
+    loginUrl.searchParams.set("state", state);
+
+    // 追加パラメータ（provider等）
+    if (config.loginParams) {
+      const paramsOrResponse = config.loginParams(c);
+      if (paramsOrResponse instanceof Response) {
+        return paramsOrResponse;
+      }
+      for (const [key, value] of Object.entries(paramsOrResponse)) {
+        loginUrl.searchParams.set(key, value);
+      }
+    }
+
+    return c.redirect(loginUrl.toString());
+  });
+
+  // GET /auth/callback
+  app.get("/callback", async (c) => {
+    const code = c.req.query("code");
+    const state = c.req.query("state");
+
+    if (!code || !state) {
+      return c.redirect("/?error=missing_params");
+    }
+
+    const stateError = verifyAndConsumeOAuthState(c, config.stateCookieName, state);
+    if (stateError) {
+      return c.redirect(`/?error=${stateError}`);
+    }
+
+    const callbackUrl = `${c.env.SELF_ORIGIN}/auth/callback`;
+    const result = await exchangeCodeAtIdp(c.env, code, callbackUrl);
+
+    if (!result.ok) {
+      return c.redirect("/?error=exchange_failed");
+    }
+
+    // 追加チェック（admin role検証等）
+    if (config.onCallbackCheck) {
+      const checkResult = await config.onCallbackCheck(c, result.data);
+      if (checkResult) {
+        return checkResult;
+      }
+    }
+
+    await setSessionCookie(c, config.sessionCookieName, {
+      access_token: result.data.access_token,
+      refresh_token: result.data.refresh_token,
+      user: result.data.user,
+    });
+
+    return c.redirect(config.successRedirect);
+  });
+
+  // POST /auth/logout
+  app.post("/logout", async (c) => {
+    const sessionData = await parseSession(
+      getCookie(c, config.sessionCookieName),
+      c.env.SESSION_SECRET,
+    );
+    if (sessionData) {
+      try {
+        await revokeTokenAtIdp(c.env, sessionData.refresh_token);
+      } catch (err) {
+        logger.error("[logout] IdP revoke request failed", err);
+      }
+    }
+
+    deleteCookie(c, config.sessionCookieName, {
+      path: "/",
+      secure: true,
+      httpOnly: true,
+      sameSite: "Lax",
+    });
+    return c.redirect("/");
+  });
+
+  return app;
+}

--- a/workers/admin/src/index.test.ts
+++ b/workers/admin/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 
-vi.mock("@0g0-id/shared", () => ({
+vi.mock("@0g0-id/shared", async (importOriginal) => ({
+  ...(await importOriginal()),
   logger: () => async (_c: unknown, next: () => Promise<void>) => next(),
   securityHeaders: () => async (_c: unknown, next: () => Promise<void>) => next(),
   bodyLimitMiddleware: () => async (_c: unknown, next: () => Promise<void>) => next(),

--- a/workers/admin/src/routes/auth.test.ts
+++ b/workers/admin/src/routes/auth.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import { Hono } from "hono";
 
-vi.mock("@0g0-id/shared", async () => ({
-  ...(await vi.importActual("@0g0-id/shared")),
-  generateToken: vi.fn(),
-}));
-
-import { generateToken, encodeSession } from "@0g0-id/shared";
+import { encodeSession } from "@0g0-id/shared";
 import authRoutes from "./auth";
 
 const baseUrl = "https://admin.0g0.xyz";
@@ -51,7 +46,6 @@ function makeExchangeResponse(role: "admin" | "user" = "admin") {
 describe("admin BFF — /auth", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(generateToken).mockReturnValue("mock-state-token");
   });
 
   // ===== GET /auth/login =====
@@ -63,7 +57,7 @@ describe("admin BFF — /auth", () => {
       expect(res.status).toBe(302);
       const location = res.headers.get("location") ?? "";
       expect(location).toContain("https://id.0g0.xyz/auth/login");
-      expect(location).toContain("state=mock-state-token");
+      expect(location).toMatch(/state=[A-Za-z0-9_-]+/);
       expect(location).toContain("redirect_to=");
 
       // state cookie が設定されていることを確認

--- a/workers/admin/src/routes/auth.ts
+++ b/workers/admin/src/routes/auth.ts
@@ -1,95 +1,26 @@
-import { Hono } from "hono";
-import { getCookie, deleteCookie } from "hono/cookie";
-import {
-  generateToken,
-  parseSession,
-  setSessionCookie,
-  createLogger,
-  setOAuthStateCookie,
-  verifyAndConsumeOAuthState,
-  exchangeCodeAtIdp,
-  revokeTokenAtIdp,
-} from "@0g0-id/shared";
-import type { BffEnv } from "@0g0-id/shared";
-
-const app = new Hono<{ Bindings: BffEnv }>();
+import { createBffAuthRoutes, revokeTokenAtIdp, createLogger } from "@0g0-id/shared";
 
 const adminAuthLogger = createLogger("admin-auth");
 
 const SESSION_COOKIE = "__Host-admin-session";
-const STATE_COOKIE = "__Host-admin-oauth-state";
 
-// GET /auth/login
-app.get("/login", async (c) => {
-  const state = generateToken(16);
-  const callbackUrl = `${c.env.SELF_ORIGIN}/auth/callback`;
-
-  setOAuthStateCookie(c, STATE_COOKIE, state);
-
-  const loginUrl = new URL(`${c.env.IDP_ORIGIN}/auth/login`);
-  loginUrl.searchParams.set("redirect_to", callbackUrl);
-  loginUrl.searchParams.set("state", state);
-
-  return c.redirect(loginUrl.toString());
-});
-
-// GET /auth/callback
-app.get("/callback", async (c) => {
-  const code = c.req.query("code");
-  const state = c.req.query("state");
-
-  if (!code || !state) {
-    return c.redirect("/?error=missing_params");
-  }
-
-  const stateError = verifyAndConsumeOAuthState(c, STATE_COOKIE, state);
-  if (stateError) {
-    return c.redirect(`/?error=${stateError}`);
-  }
-
-  const callbackUrl = `${c.env.SELF_ORIGIN}/auth/callback`;
-  const result = await exchangeCodeAtIdp(c.env, code, callbackUrl);
-
-  if (!result.ok) {
-    return c.redirect("/?error=exchange_failed");
-  }
-
-  // 管理者チェック
-  if (result.data.user.role !== "admin") {
-    // 非管理者ユーザーのリフレッシュトークンを失効させる（孤立トークン防止）
-    try {
-      await revokeTokenAtIdp(c.env, result.data.refresh_token);
-    } catch (err) {
-      // 失効に失敗してもリダイレクトは継続
-      adminAuthLogger.warn("[admin-callback] IdP logout request failed for non-admin user", err);
+const app = createBffAuthRoutes({
+  sessionCookieName: SESSION_COOKIE,
+  stateCookieName: "__Host-admin-oauth-state",
+  loggerName: "admin-auth",
+  successRedirect: "/dashboard",
+  onCallbackCheck: async (c, result) => {
+    if (result.user.role !== "admin") {
+      // 非管理者ユーザーのリフレッシュトークンを失効させる（孤立トークン防止）
+      try {
+        await revokeTokenAtIdp(c.env, result.refresh_token);
+      } catch (err) {
+        adminAuthLogger.warn("[admin-callback] IdP logout request failed for non-admin user", err);
+      }
+      return c.redirect("/?error=not_admin");
     }
-    return c.redirect("/?error=not_admin");
-  }
-
-  await setSessionCookie(c, SESSION_COOKIE, {
-    access_token: result.data.access_token,
-    refresh_token: result.data.refresh_token,
-    user: result.data.user,
-  });
-
-  return c.redirect("/dashboard");
-});
-
-// POST /auth/logout
-app.post("/logout", async (c) => {
-  const session = getCookie(c, SESSION_COOKIE);
-  const sessionData = await parseSession(session, c.env.SESSION_SECRET);
-  if (sessionData) {
-    try {
-      await revokeTokenAtIdp(c.env, sessionData.refresh_token);
-    } catch (err) {
-      // IdP側のトークン失効に失敗してもCookie削除は継続するが、ログに記録する
-      adminAuthLogger.error("[logout] IdP revoke request failed", err);
-    }
-  }
-
-  deleteCookie(c, SESSION_COOKIE, { path: "/", secure: true, httpOnly: true, sameSite: "Lax" });
-  return c.redirect("/");
+    return null;
+  },
 });
 
 export default app;

--- a/workers/user/src/index.test.ts
+++ b/workers/user/src/index.test.ts
@@ -8,7 +8,8 @@ vi.mock("./middleware/cors", () => ({
   userCorsMiddleware: async (_c: unknown, next: () => Promise<void>) => next(),
 }));
 
-vi.mock("@0g0-id/shared", () => ({
+vi.mock("@0g0-id/shared", async (importOriginal) => ({
+  ...(await importOriginal()),
   logger: () => async (_c: unknown, next: () => Promise<void>) => next(),
   securityHeaders: () => async (_c: unknown, next: () => Promise<void>) => next(),
   bodyLimitMiddleware: () => async (_c: unknown, next: () => Promise<void>) => next(),

--- a/workers/user/src/routes/auth.ts
+++ b/workers/user/src/routes/auth.ts
@@ -1,93 +1,40 @@
 import { Hono } from "hono";
-import { getCookie, deleteCookie } from "hono/cookie";
+import { getCookie } from "hono/cookie";
 import {
   generateToken,
   isValidProvider,
   parseSession,
-  setSessionCookie,
   createLogger,
   internalServiceHeaders,
   setOAuthStateCookie,
-  verifyAndConsumeOAuthState,
-  exchangeCodeAtIdp,
-  revokeTokenAtIdp,
+  createBffAuthRoutes,
 } from "@0g0-id/shared";
 import type { BffEnv } from "@0g0-id/shared";
-
-const app = new Hono<{ Bindings: BffEnv }>();
 
 const userAuthLogger = createLogger("user-auth");
 
 const SESSION_COOKIE = "__Host-user-session";
 const STATE_COOKIE = "__Host-user-oauth-state";
 
-// GET /auth/login
-app.get("/login", async (c) => {
-  const provider = c.req.query("provider") ?? "google";
-  if (!isValidProvider(provider)) {
-    return c.redirect("/?error=invalid_provider");
-  }
-
-  const state = generateToken(16);
-  const callbackUrl = `${c.env.SELF_ORIGIN}/auth/callback`;
-
-  setOAuthStateCookie(c, STATE_COOKIE, state);
-
-  const loginUrl = new URL(`${c.env.IDP_ORIGIN}/auth/login`);
-  loginUrl.searchParams.set("redirect_to", callbackUrl);
-  loginUrl.searchParams.set("state", state);
-  loginUrl.searchParams.set("provider", provider);
-
-  return c.redirect(loginUrl.toString());
-});
-
-// GET /auth/callback
-app.get("/callback", async (c) => {
-  const code = c.req.query("code");
-  const state = c.req.query("state");
-
-  if (!code || !state) {
-    return c.redirect("/?error=missing_params");
-  }
-
-  const stateError = verifyAndConsumeOAuthState(c, STATE_COOKIE, state);
-  if (stateError) {
-    return c.redirect(`/?error=${stateError}`);
-  }
-
-  // id worker にコード交換リクエスト（Service Bindings使用）
-  const callbackUrl = `${c.env.SELF_ORIGIN}/auth/callback`;
-  const result = await exchangeCodeAtIdp(c.env, code, callbackUrl);
-
-  if (!result.ok) {
-    return c.redirect("/?error=exchange_failed");
-  }
-
-  // セッションCookieにトークンを保存
-  await setSessionCookie(c, SESSION_COOKIE, {
-    access_token: result.data.access_token,
-    refresh_token: result.data.refresh_token,
-    user: result.data.user,
-  });
-
-  return c.redirect("/profile");
-});
-
-// POST /auth/logout
-app.post("/logout", async (c) => {
-  const sessionData = await parseSession(getCookie(c, SESSION_COOKIE), c.env.SESSION_SECRET);
-  if (sessionData) {
-    try {
-      await revokeTokenAtIdp(c.env, sessionData.refresh_token);
-    } catch (err) {
-      // IdP側のトークン失効に失敗してもCookie削除は継続するが、ログに記録する
-      userAuthLogger.error("[logout] IdP revoke request failed", err);
+// 共通認証ルート（login / callback / logout）
+const authRoutes = createBffAuthRoutes({
+  sessionCookieName: SESSION_COOKIE,
+  stateCookieName: STATE_COOKIE,
+  loggerName: "user-auth",
+  successRedirect: "/profile",
+  loginParams: (c) => {
+    const provider = c.req.query("provider") ?? "google";
+    if (!isValidProvider(provider)) {
+      return c.redirect("/?error=invalid_provider");
     }
-  }
-
-  deleteCookie(c, SESSION_COOKIE, { path: "/", secure: true, httpOnly: true, sameSite: "Lax" });
-  return c.redirect("/");
+    return { provider };
+  },
 });
+
+const app = new Hono<{ Bindings: BffEnv }>();
+
+// 共通ルートをマウント
+app.route("/", authRoutes);
 
 // POST /auth/link — ログイン済みユーザーがSNSプロバイダー連携を開始
 // GETではなくPOSTにすることでbffCsrfMiddlewareによるOriginヘッダー検証を適用し、


### PR DESCRIPTION
## Summary
- `packages/shared/src/lib/bff-auth-factory.ts` に `createBffAuthRoutes` ファクトリを新設
- admin/user の auth.ts から login/callback/logout の重複ロジックを削除し、ファクトリ呼び出しに置き換え
- admin固有の role チェック → `onCallbackCheck` フック、user固有の provider 選択 → `loginParams` フックで差分のみ渡す構成

Closes #112

## Test plan
- [x] 全テスト通過（2376 tests passed）
- [x] `npx vp check` 通過（lint + format + typecheck）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized authentication route handling across services using a shared factory pattern, improving consistency and maintainability of login, callback, and logout flows.

* **Tests**
  * Updated test mocking to better reflect the refactored shared module structure and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->