### PR TITLE
セキュリティ対応: vite-plus バージョン指定を統一 (#123)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4003,7 +4003,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260329.1",
         "typescript": "^6.0.2",
-        "vite-plus": "latest",
+        "vite-plus": "^0.1.18",
         "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
       }
     },
@@ -4019,7 +4019,7 @@
         "@cloudflare/workers-types": "^4.20260329.1",
         "typescript": "^6.0.2",
         "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-        "vite-plus": "latest",
+        "vite-plus": "^0.1.18",
         "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
         "wrangler": "^4.78.0"
       }
@@ -4039,7 +4039,7 @@
         "@cloudflare/workers-types": "^4.20260329.1",
         "typescript": "^6.0.2",
         "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-        "vite-plus": "latest",
+        "vite-plus": "^0.1.18",
         "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
         "wrangler": "^4.78.0"
       }
@@ -4058,7 +4058,7 @@
         "@cloudflare/workers-types": "^4.20260329.1",
         "typescript": "^6.0.2",
         "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-        "vite-plus": "latest",
+        "vite-plus": "^0.1.18",
         "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
         "wrangler": "^4.78.0"
       }
@@ -4075,7 +4075,7 @@
         "@cloudflare/workers-types": "^4.20260329.1",
         "typescript": "^6.0.2",
         "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-        "vite-plus": "latest",
+        "vite-plus": "^0.1.18",
         "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
         "wrangler": "^4.78.0"
       }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260329.1",
     "typescript": "^6.0.2",
-    "vite-plus": "latest",
+    "vite-plus": "^0.1.18",
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
   }
 }

--- a/workers/admin/package.json
+++ b/workers/admin/package.json
@@ -19,7 +19,7 @@
     "@cloudflare/workers-types": "^4.20260329.1",
     "typescript": "^6.0.2",
     "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest",
+    "vite-plus": "^0.1.18",
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
     "wrangler": "^4.78.0"
   }

--- a/workers/id/package.json
+++ b/workers/id/package.json
@@ -22,7 +22,7 @@
     "@cloudflare/workers-types": "^4.20260329.1",
     "typescript": "^6.0.2",
     "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest",
+    "vite-plus": "^0.1.18",
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
     "wrangler": "^4.78.0"
   }

--- a/workers/mcp/package.json
+++ b/workers/mcp/package.json
@@ -20,7 +20,7 @@
     "@cloudflare/workers-types": "^4.20260329.1",
     "typescript": "^6.0.2",
     "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest",
+    "vite-plus": "^0.1.18",
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
     "wrangler": "^4.78.0"
   }

--- a/workers/user/package.json
+++ b/workers/user/package.json
@@ -19,7 +19,7 @@
     "@cloudflare/workers-types": "^4.20260329.1",
     "typescript": "^6.0.2",
     "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-    "vite-plus": "latest",
+    "vite-plus": "^0.1.18",
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
     "wrangler": "^4.78.0"
   }


### PR DESCRIPTION
## Summary

- 各ワークスペースの `package.json` で `vite-plus` が `"latest"` 指定だったのを `"^0.1.18"` に統一
- Dependabot High アラート5件（#19, #21, #22, #23, #24）の解消を目的

## Test plan

- [x] `npx vp check` パス（lint + format + typecheck）
- [x] テスト 2376件 全パス
- [x] `npm audit` で 0 vulnerabilities

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling versions across development packages to improve stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->