### PR TITLE
リファクタリング: エラーレスポンス形式統一ヘルパー追加 (#125)

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -16,9 +16,58 @@ paths:
 
 ### エラーレスポンス
 
+本プロジェクトでは 2 種類のエラーレスポンス形式を使い分ける。
+
+#### 1. REST API 形式（既定）
+
+`/api/*`、`/auth/exchange`、`/auth/refresh`、`/auth/logout`、`/auth/callback` など、
+OAuth 2.0 規格外のREST系エンドポイントで使用する。
+
 ```json
 { "error": { "code": "ERROR_CODE", "message": "説明" } }
 ```
+
+共通ヘルパー: `restErrorBody(code, message)`（`packages/shared/src/lib/errors.ts`）
+
+```typescript
+import { restErrorBody } from "@0g0-id/shared";
+
+return c.json(restErrorBody("NOT_FOUND", "User not found"), 404);
+```
+
+標準エラーコード（追加は自由、固有コードは用途を明確に命名する）:
+
+| code                | HTTP status | 用途                 |
+| ------------------- | ----------- | -------------------- |
+| `BAD_REQUEST`       | 400         | バリデーションエラー |
+| `UNAUTHORIZED`      | 401         | 認証失敗             |
+| `FORBIDDEN`         | 403         | 権限不足             |
+| `NOT_FOUND`         | 404         | リソース未検出       |
+| `CONFLICT`          | 409         | 競合（重複登録等）   |
+| `TOO_MANY_REQUESTS` | 429         | レートリミット       |
+| `INTERNAL_ERROR`    | 500         | サーバーエラー       |
+
+#### 2. OAuth 2.0 (RFC 6749) 形式
+
+`/api/token/*`、`/auth/authorize`、`/api/userinfo`（OIDC）等、OAuth/OIDC 仕様準拠が必要なエンドポイントで使用する。
+コードは RFC 6749 準拠の小文字スネーク（`invalid_request` / `invalid_grant` / `server_error` 等）。
+
+```json
+{ "error": "invalid_request", "error_description": "client_id is required" }
+```
+
+共通ヘルパー: `oauthErrorBody(error, description?)`（`packages/shared/src/lib/errors.ts`）
+
+```typescript
+import { oauthErrorBody } from "@0g0-id/shared";
+
+return c.json(oauthErrorBody("invalid_request", "client_id is required"), 400);
+```
+
+#### 選択基準
+
+- OAuth 2.0 / OIDC 仕様が規定するエンドポイント → OAuth 形式（仕様準拠が必須）
+- それ以外のBFF・管理API・外部API → REST 形式
 
 ## HTTPステータスコード
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,6 +24,7 @@ export * from "./lib/sql";
 export * from "./lib/redirect-uri";
 export * from "./lib/validation";
 export * from "./lib/cookie";
+export * from "./lib/errors";
 export * from "./db/users";
 export * from "./db/services";
 export * from "./db/service-redirect-uris";

--- a/packages/shared/src/lib/errors.ts
+++ b/packages/shared/src/lib/errors.ts
@@ -1,0 +1,70 @@
+/**
+ * エラーレスポンス形式を統一するためのヘルパー。
+ *
+ * 本プロジェクトでは 2 種類のエラーレスポンス形式を使い分ける。
+ *
+ * 1. REST API 形式（`{ error: { code, message } }`）
+ *    - `/api/users/*`, `/api/services/*`, `/api/metrics` 等のREST系エンドポイント
+ *    - コードは大文字スネーク（`BAD_REQUEST` / `NOT_FOUND` 等）
+ *
+ * 2. OAuth 2.0 (RFC 6749) 形式（`{ error, error_description? }`）
+ *    - `/api/token/*`, `/auth/authorize` 等の OAuth 系エンドポイント
+ *    - コードは RFC 6749 準拠の小文字スネーク（`invalid_request` / `invalid_grant` 等）
+ *
+ * 仕様の詳細は `.claude/rules/api.md` を参照。
+ */
+
+/**
+ * REST API で使用する標準エラーコード。
+ * ルートごとに追加の固有コード（例: `TOKEN_ROTATED`, `INVALID_LINK_TOKEN`）を付けてよい。
+ */
+export const REST_ERROR_CODES = {
+  BAD_REQUEST: "BAD_REQUEST",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  FORBIDDEN: "FORBIDDEN",
+  NOT_FOUND: "NOT_FOUND",
+  CONFLICT: "CONFLICT",
+  TOO_MANY_REQUESTS: "TOO_MANY_REQUESTS",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const;
+
+export type RestErrorCode = (typeof REST_ERROR_CODES)[keyof typeof REST_ERROR_CODES];
+
+/**
+ * REST API エラーレスポンスのボディ。
+ */
+export interface RestErrorBody {
+  error: {
+    code: string;
+    message: string;
+  };
+}
+
+/**
+ * OAuth 2.0 (RFC 6749) 形式のエラーレスポンスボディ。
+ */
+export interface OAuthErrorBody {
+  error: string;
+  error_description?: string;
+  error_uri?: string;
+}
+
+/**
+ * REST API エラーボディを生成する。
+ *
+ * @example
+ *   return c.json(restErrorBody("NOT_FOUND", "User not found"), 404);
+ */
+export function restErrorBody(code: string, message: string): RestErrorBody {
+  return { error: { code, message } };
+}
+
+/**
+ * OAuth 2.0 (RFC 6749) エラーボディを生成する。
+ *
+ * @example
+ *   return c.json(oauthErrorBody("invalid_request", "client_id is required"), 400);
+ */
+export function oauthErrorBody(error: string, description?: string): OAuthErrorBody {
+  return description === undefined ? { error } : { error, error_description: description };
+}

--- a/workers/id/src/routes/admin-audit-logs.test.ts
+++ b/workers/id/src/routes/admin-audit-logs.test.ts
@@ -1,48 +1,52 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import { Hono } from "hono";
 
-vi.mock("@0g0-id/shared", () => ({
-  createLogger: vi
-    .fn()
-    .mockReturnValue({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
-  findUserById: vi.fn(),
-  listAdminAuditLogs: vi.fn(),
-  getAuditLogStats: vi.fn(),
-  parseDays: (
-    daysParam: string | undefined,
-    options: { minDays?: number; maxDays?: number } = {},
-  ) => {
-    if (daysParam === undefined) return undefined;
-    const { minDays = 1, maxDays = 90 } = options;
-    const days = parseInt(daysParam, 10);
-    if (!Number.isInteger(days) || days < minDays || days > maxDays) {
-      return {
-        error: {
-          code: "INVALID_REQUEST",
-          message: `days must be an integer between ${minDays} and ${maxDays}`,
-        },
-      };
-    }
-    return { days };
-  },
-  parsePagination: (
-    query: { limit?: string; offset?: string },
-    options: { defaultLimit: number; maxLimit: number } = { defaultLimit: 50, maxLimit: 100 },
-  ) => {
-    const limitRaw = query.limit !== undefined ? parseInt(query.limit, 10) : options.defaultLimit;
-    const offsetRaw = query.offset !== undefined ? parseInt(query.offset, 10) : 0;
-    if (query.limit !== undefined && (isNaN(limitRaw) || limitRaw < 1)) {
-      return { error: "limit は1以上の整数で指定してください" };
-    }
-    if (query.offset !== undefined && (isNaN(offsetRaw) || offsetRaw < 0)) {
-      return { error: "offset は0以上の整数で指定してください" };
-    }
-    return { limit: Math.min(limitRaw, options.maxLimit), offset: offsetRaw };
-  },
-  verifyAccessToken: vi.fn(),
-  isAccessTokenRevoked: vi.fn().mockResolvedValue(false),
-  UUID_RE: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
-}));
+vi.mock("@0g0-id/shared", async (importOriginal) => {
+  const { restErrorBody } = await importOriginal<typeof import("@0g0-id/shared")>();
+  return {
+    restErrorBody,
+    createLogger: vi
+      .fn()
+      .mockReturnValue({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    findUserById: vi.fn(),
+    listAdminAuditLogs: vi.fn(),
+    getAuditLogStats: vi.fn(),
+    parseDays: (
+      daysParam: string | undefined,
+      options: { minDays?: number; maxDays?: number } = {},
+    ) => {
+      if (daysParam === undefined) return undefined;
+      const { minDays = 1, maxDays = 90 } = options;
+      const days = parseInt(daysParam, 10);
+      if (!Number.isInteger(days) || days < minDays || days > maxDays) {
+        return {
+          error: {
+            code: "INVALID_REQUEST",
+            message: `days must be an integer between ${minDays} and ${maxDays}`,
+          },
+        };
+      }
+      return { days };
+    },
+    parsePagination: (
+      query: { limit?: string; offset?: string },
+      options: { defaultLimit: number; maxLimit: number } = { defaultLimit: 50, maxLimit: 100 },
+    ) => {
+      const limitRaw = query.limit !== undefined ? parseInt(query.limit, 10) : options.defaultLimit;
+      const offsetRaw = query.offset !== undefined ? parseInt(query.offset, 10) : 0;
+      if (query.limit !== undefined && (isNaN(limitRaw) || limitRaw < 1)) {
+        return { error: "limit は1以上の整数で指定してください" };
+      }
+      if (query.offset !== undefined && (isNaN(offsetRaw) || offsetRaw < 0)) {
+        return { error: "offset は0以上の整数で指定してください" };
+      }
+      return { limit: Math.min(limitRaw, options.maxLimit), offset: offsetRaw };
+    },
+    verifyAccessToken: vi.fn(),
+    isAccessTokenRevoked: vi.fn().mockResolvedValue(false),
+    UUID_RE: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+  };
+});
 
 import {
   findUserById,

--- a/workers/id/src/routes/admin-audit-logs.ts
+++ b/workers/id/src/routes/admin-audit-logs.ts
@@ -4,6 +4,7 @@ import {
   getAuditLogStats,
   parsePagination,
   parseDays,
+  restErrorBody,
   UUID_RE,
 } from "@0g0-id/shared";
 import type { IdpEnv, TokenPayload } from "@0g0-id/shared";
@@ -18,7 +19,7 @@ const app = new Hono<{ Bindings: IdpEnv; Variables: Variables }>();
 app.get("/stats", authMiddleware, adminMiddleware, async (c) => {
   const daysResult = parseDays(c.req.query("days"));
   if (daysResult !== undefined && "error" in daysResult) {
-    return c.json({ error: { code: "BAD_REQUEST", message: daysResult.error } }, 400);
+    return c.json({ error: daysResult.error }, 400);
   }
   const days = daysResult?.days ?? 30;
 
@@ -26,7 +27,7 @@ app.get("/stats", authMiddleware, adminMiddleware, async (c) => {
     const stats = await getAuditLogStats(c.env.DB, days);
     return c.json({ data: stats, days });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 
@@ -46,13 +47,13 @@ app.get("/", authMiddleware, adminMiddleware, async (c) => {
   const action = c.req.query("action");
 
   if (adminUserId !== undefined && !UUID_RE.test(adminUserId)) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid admin_user_id format" } }, 400);
+    return c.json(restErrorBody("BAD_REQUEST", "Invalid admin_user_id format"), 400);
   }
   if (targetId !== undefined && !UUID_RE.test(targetId)) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid target_id format" } }, 400);
+    return c.json(restErrorBody("BAD_REQUEST", "Invalid target_id format"), 400);
   }
   if (action !== undefined && !/^[a-z]+\.[a-z_]+$/.test(action)) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid action format" } }, 400);
+    return c.json(restErrorBody("BAD_REQUEST", "Invalid action format"), 400);
   }
 
   try {
@@ -66,7 +67,7 @@ app.get("/", authMiddleware, adminMiddleware, async (c) => {
       pagination: { total, limit, offset },
     });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 

--- a/workers/id/src/routes/auth.test.ts
+++ b/workers/id/src/routes/auth.test.ts
@@ -5,9 +5,12 @@ import { createMockIdpEnv } from "../../../../packages/shared/src/db/test-helper
 
 // @0g0-id/sharedの全関数をモック
 vi.mock("@0g0-id/shared", async (importOriginal) => {
-  const { parseJsonBody } = await importOriginal<typeof import("@0g0-id/shared")>();
+  const { parseJsonBody, restErrorBody, oauthErrorBody } =
+    await importOriginal<typeof import("@0g0-id/shared")>();
   return {
     parseJsonBody,
+    restErrorBody,
+    oauthErrorBody,
     createLogger: vi
       .fn()
       .mockReturnValue({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),

--- a/workers/id/src/routes/auth/logout.ts
+++ b/workers/id/src/routes/auth/logout.ts
@@ -9,6 +9,7 @@ import {
   verifyAccessToken,
   addRevokedAccessToken,
   createLogger,
+  restErrorBody,
 } from "@0g0-id/shared";
 
 const authLogger = createLogger("auth");
@@ -53,20 +54,14 @@ export async function handleLogout(c: Context<{ Bindings: IdpEnv; Variables: Var
       storedToken = await findRefreshTokenByHash(c.env.DB, tokenHash);
     } catch (err) {
       authLogger.error("[logout] Failed to find refresh token", err);
-      return c.json(
-        { error: { code: "INTERNAL_ERROR", message: "Failed to process logout" } },
-        500,
-      );
+      return c.json(restErrorBody("INTERNAL_ERROR", "Failed to process logout"), 500);
     }
     if (storedToken && storedToken.revoked_at === null) {
       try {
         await revokeRefreshToken(c.env.DB, storedToken.id, "user_logout");
       } catch (err) {
         authLogger.error("[logout] Failed to revoke refresh token", err);
-        return c.json(
-          { error: { code: "INTERNAL_ERROR", message: "Failed to revoke token" } },
-          500,
-        );
+        return c.json(restErrorBody("INTERNAL_ERROR", "Failed to revoke token"), 500);
       }
     }
   }

--- a/workers/id/src/routes/auth/refresh.ts
+++ b/workers/id/src/routes/auth/refresh.ts
@@ -1,7 +1,14 @@
 import type { Context } from "hono";
 import { z } from "zod";
 import type { IdpEnv, Service, TokenPayload } from "@0g0-id/shared";
-import { parseJsonBody, sha256, findUserById, findServiceById, createLogger } from "@0g0-id/shared";
+import {
+  parseJsonBody,
+  sha256,
+  findUserById,
+  findServiceById,
+  createLogger,
+  restErrorBody,
+} from "@0g0-id/shared";
 import { resolveEffectiveScope } from "../../utils/scopes";
 import { ACCESS_TOKEN_TTL_SECONDS } from "../../utils/token-pair";
 import {
@@ -30,36 +37,31 @@ export async function handleRefresh(c: Context<{ Bindings: IdpEnv; Variables: Va
   if (!validationResult.ok) {
     if (validationResult.reason === "TOKEN_ROTATED") {
       return c.json(
-        {
-          error: { code: "TOKEN_ROTATED", message: "Token already rotated, retry with new token" },
-        },
+        restErrorBody("TOKEN_ROTATED", "Token already rotated, retry with new token"),
         401,
       );
     }
     if (validationResult.reason === "TOKEN_REUSE") {
-      return c.json({ error: { code: "TOKEN_REUSE", message: "Token reuse detected" } }, 401);
+      return c.json(restErrorBody("TOKEN_REUSE", "Token reuse detected"), 401);
     }
-    return c.json({ error: { code: "INVALID_TOKEN", message: "Token not found" } }, 401);
+    return c.json(restErrorBody("INVALID_TOKEN", "Token not found"), 401);
   }
   const storedToken = validationResult.storedToken;
 
   // 有効期限チェック
   if (new Date(storedToken.expires_at) < new Date()) {
-    return c.json({ error: { code: "TOKEN_EXPIRED", message: "Refresh token expired" } }, 401);
+    return c.json(restErrorBody("TOKEN_EXPIRED", "Refresh token expired"), 401);
   }
 
   // ユーザー情報取得
   const user = await findUserById(c.env.DB, storedToken.user_id);
   if (!user) {
-    return c.json({ error: { code: "INVALID_GRANT", message: "User not found" } }, 401);
+    return c.json(restErrorBody("INVALID_GRANT", "User not found"), 401);
   }
 
   // BANされたユーザーのトークン更新を拒否
   if (user.banned_at !== null) {
-    return c.json(
-      { error: { code: "ACCOUNT_BANNED", message: "Your account has been suspended" } },
-      403,
-    );
+    return c.json(restErrorBody("ACCOUNT_BANNED", "Your account has been suspended"), 403);
   }
 
   // サービストークンの場合: 元のサービスのスコープを引き継ぐ
@@ -69,7 +71,7 @@ export async function handleRefresh(c: Context<{ Bindings: IdpEnv; Variables: Va
     refreshService = await findServiceById(c.env.DB, storedToken.service_id);
     if (!refreshService) {
       // サービス削除済み → トークンリフレッシュを拒否
-      return c.json({ error: { code: "INVALID_TOKEN", message: "Service no longer exists" } }, 401);
+      return c.json(restErrorBody("INVALID_TOKEN", "Service no longer exists"), 401);
     }
     // 保存済みスコープがあればそれを引き継ぐ（スコープ昇格防止）
     // 保存済みスコープがない（マイグレーション前のトークン）場合はallowed_scopesにフォールバック
@@ -93,9 +95,9 @@ export async function handleRefresh(c: Context<{ Bindings: IdpEnv; Variables: Va
   );
   if (!issueResult.ok) {
     if (issueResult.reason === "TOKEN_REUSE") {
-      return c.json({ error: { code: "TOKEN_REUSE", message: "Token reuse detected" } }, 401);
+      return c.json(restErrorBody("TOKEN_REUSE", "Token reuse detected"), 401);
     }
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Token operation failed" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Token operation failed"), 500);
   }
   const accessToken = issueResult.accessToken;
   const newRefreshTokenRaw = issueResult.refreshToken;

--- a/workers/id/src/routes/external.ts
+++ b/workers/id/src/routes/external.ts
@@ -6,6 +6,7 @@ import {
   listUsersAuthorizedForService,
   countUsersAuthorizedForService,
   parsePagination,
+  restErrorBody,
 } from "@0g0-id/shared";
 import type { IdpEnv, User, Service, AuthorizedUserFilter } from "@0g0-id/shared";
 import { serviceAuthMiddleware } from "../utils/service-auth";
@@ -62,16 +63,10 @@ app.get("/users", externalApiRateLimitMiddleware, serviceAuthMiddleware, async (
   const allowedScopes = parseAllowedScopes(service.allowed_scopes);
 
   if (nameQuery && !allowedScopes.includes("profile")) {
-    return c.json(
-      { error: { code: "FORBIDDEN", message: "name filter requires profile scope" } },
-      403,
-    );
+    return c.json(restErrorBody("FORBIDDEN", "name filter requires profile scope"), 403);
   }
   if (emailQuery && !allowedScopes.includes("email")) {
-    return c.json(
-      { error: { code: "FORBIDDEN", message: "email filter requires email scope" } },
-      403,
-    );
+    return c.json(restErrorBody("FORBIDDEN", "email filter requires email scope"), 403);
   }
 
   const filter: AuthorizedUserFilter = {
@@ -87,7 +82,7 @@ app.get("/users", externalApiRateLimitMiddleware, serviceAuthMiddleware, async (
       countUsersAuthorizedForService(c.env.DB, service.id, filter),
     ]);
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 
   // listUsersAuthorizedForService のSQLで banned_at IS NULL フィルタ済み
@@ -101,7 +96,7 @@ app.get("/users/:sub", externalApiRateLimitMiddleware, serviceAuthMiddleware, as
   const service = c.get("service");
   const requestedSub = c.req.param("sub");
   if (!/^[0-9a-f]{64}$/i.test(requestedSub)) {
-    return c.json({ error: { code: "BAD_REQUEST", message: "Invalid sub format" } }, 400);
+    return c.json(restErrorBody("BAD_REQUEST", "Invalid sub format"), 400);
   }
 
   try {
@@ -109,16 +104,16 @@ app.get("/users/:sub", externalApiRateLimitMiddleware, serviceAuthMiddleware, as
     const matchedUserId = await findUserIdByPairwiseSub(c.env.DB, service.id, requestedSub);
 
     if (!matchedUserId) {
-      return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
+      return c.json(restErrorBody("NOT_FOUND", "User not found"), 404);
     }
 
     const user = await findUserById(c.env.DB, matchedUserId);
     if (!user) {
-      return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
+      return c.json(restErrorBody("NOT_FOUND", "User not found"), 404);
     }
     // BAN済みユーザーは外部サービスに公開しない
     if (user.banned_at !== null) {
-      return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
+      return c.json(restErrorBody("NOT_FOUND", "User not found"), 404);
     }
 
     const allowedScopes = parseAllowedScopes(service.allowed_scopes);
@@ -126,7 +121,7 @@ app.get("/users/:sub", externalApiRateLimitMiddleware, serviceAuthMiddleware, as
 
     return c.json({ data });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 

--- a/workers/id/src/routes/metrics.test.ts
+++ b/workers/id/src/routes/metrics.test.ts
@@ -1,28 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
 import { Hono } from "hono";
 
-vi.mock("@0g0-id/shared", () => ({
-  createLogger: vi
-    .fn()
-    .mockReturnValue({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
-  countUsers: vi.fn(),
-  countAdminUsers: vi.fn(),
-  countServices: vi.fn(),
-  countActiveRefreshTokens: vi.fn(),
-  countRecentLoginEvents: vi.fn(),
-  getLoginEventProviderStats: vi.fn(),
-  getLoginEventCountryStats: vi.fn(),
-  getDailyLoginTrends: vi.fn(),
-  verifyAccessToken: vi.fn(),
-  isAccessTokenRevoked: vi.fn().mockResolvedValue(false),
-  findUserById: vi.fn(),
-  getServiceTokenStats: vi.fn(),
-  getSuspiciousMultiCountryLogins: vi.fn(),
-  getDailyUserRegistrations: vi.fn(),
-  getActiveUserStats: vi.fn(),
-  getDailyActiveUsers: vi.fn(),
-  parseDays: vi.fn(),
-}));
+vi.mock("@0g0-id/shared", async (importOriginal) => {
+  const { restErrorBody } = await importOriginal<typeof import("@0g0-id/shared")>();
+  return {
+    restErrorBody,
+    createLogger: vi
+      .fn()
+      .mockReturnValue({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    countUsers: vi.fn(),
+    countAdminUsers: vi.fn(),
+    countServices: vi.fn(),
+    countActiveRefreshTokens: vi.fn(),
+    countRecentLoginEvents: vi.fn(),
+    getLoginEventProviderStats: vi.fn(),
+    getLoginEventCountryStats: vi.fn(),
+    getDailyLoginTrends: vi.fn(),
+    verifyAccessToken: vi.fn(),
+    isAccessTokenRevoked: vi.fn().mockResolvedValue(false),
+    findUserById: vi.fn(),
+    getServiceTokenStats: vi.fn(),
+    getSuspiciousMultiCountryLogins: vi.fn(),
+    getDailyUserRegistrations: vi.fn(),
+    getActiveUserStats: vi.fn(),
+    getDailyActiveUsers: vi.fn(),
+    parseDays: vi.fn(),
+  };
+});
 
 import {
   countUsers,

--- a/workers/id/src/routes/metrics.ts
+++ b/workers/id/src/routes/metrics.ts
@@ -14,6 +14,7 @@ import {
   getActiveUserStats,
   getDailyActiveUsers,
   parseDays,
+  restErrorBody,
 } from "@0g0-id/shared";
 import type { IdpEnv, TokenPayload, AdminMetrics } from "@0g0-id/shared";
 import { authMiddleware } from "../middleware/auth";
@@ -66,7 +67,7 @@ app.get("/", authMiddleware, adminMiddleware, async (c) => {
       } satisfies AdminMetrics,
     });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Failed to fetch metrics" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Failed to fetch metrics"), 500);
   }
 });
 
@@ -82,7 +83,7 @@ app.get("/login-trends", authMiddleware, adminMiddleware, async (c) => {
     const trends = await getDailyLoginTrends(c.env.DB, days);
     return c.json({ data: trends, days });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 
@@ -92,7 +93,7 @@ app.get("/services", authMiddleware, adminMiddleware, async (c) => {
     const stats = await getServiceTokenStats(c.env.DB);
     return c.json({ data: stats });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 
@@ -111,7 +112,7 @@ app.get("/suspicious-logins", authMiddleware, adminMiddleware, async (c) => {
     const logins = await getSuspiciousMultiCountryLogins(c.env.DB, sinceIso, minCountries);
     return c.json({ data: logins, meta: { hours, min_countries: minCountries } });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 
@@ -127,7 +128,7 @@ app.get("/user-registrations", authMiddleware, adminMiddleware, async (c) => {
     const registrations = await getDailyUserRegistrations(c.env.DB, days);
     return c.json({ data: registrations, days });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 
@@ -137,7 +138,7 @@ app.get("/active-users", authMiddleware, adminMiddleware, async (c) => {
     const stats = await getActiveUserStats(c.env.DB);
     return c.json({ data: stats });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 
@@ -152,7 +153,7 @@ app.get("/active-users/daily", authMiddleware, adminMiddleware, async (c) => {
     const data = await getDailyActiveUsers(c.env.DB, days);
     return c.json({ data, days });
   } catch {
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    return c.json(restErrorBody("INTERNAL_ERROR", "Internal server error"), 500);
   }
 });
 

--- a/workers/id/src/routes/userinfo.ts
+++ b/workers/id/src/routes/userinfo.ts
@@ -1,6 +1,6 @@
 import { Hono, type Context } from "hono";
 import type { IdpEnv, TokenPayload } from "@0g0-id/shared";
-import { findUserById, generatePairwiseSub } from "@0g0-id/shared";
+import { findUserById, generatePairwiseSub, oauthErrorBody } from "@0g0-id/shared";
 import { authMiddleware } from "../middleware/auth";
 import { externalApiRateLimitMiddleware } from "../middleware/rate-limit";
 
@@ -21,15 +21,15 @@ async function handleUserInfo(c: AppContext): Promise<Response> {
   try {
     user = await findUserById(c.env.DB, tokenUser.sub);
   } catch {
-    return c.json({ error: "server_error", error_description: "Internal server error" }, 500);
+    return c.json(oauthErrorBody("server_error", "Internal server error"), 500);
   }
   if (!user) {
-    return c.json({ error: "invalid_token", error_description: "User not found" }, 401);
+    return c.json(oauthErrorBody("invalid_token", "User not found"), 401);
   }
 
   // BAN済みユーザーのクレーム返却を防止
   if (user.banned_at !== null) {
-    return c.json({ error: "invalid_token", error_description: "Account suspended" }, 401);
+    return c.json(oauthErrorBody("invalid_token", "Account suspended"), 401);
   }
 
   // スコープベースのクレームフィルタリング（OIDC Core 1.0 Section 5.3）


### PR DESCRIPTION
## Summary

- `packages/shared/src/lib/errors.ts` を新設し、エラーレスポンス形式を統一する共通ヘルパーを提供
  - `restErrorBody(code, message)`: REST API 形式 `{ error: { code, message } }`
  - `oauthErrorBody(error, description?)`: OAuth 2.0 (RFC 6749) 形式 `{ error, error_description? }`
- 代表的なroutes 6ファイルをヘルパー経由に移行（external, metrics, admin-audit-logs, userinfo, auth/logout, auth/refresh）
- `.claude/rules/api.md` にエラー形式の選択基準・標準エラーコード一覧・使用例を文書化
- 副次的バグ修正: `admin-audit-logs.ts` の `message` フィールドに object が入ってしまう不整合を解消

残りのroutes（users / services / device / auth/authorize / auth/callback / auth/exchange / auth/login / token/\*）は後続PRで順次ヘルパーに置換可能。既存形式との互換性は維持。

関連 issue: Close #125

## Test plan

- [x] `npx vp check` 通過（lint / format / typecheck）
- [x] `npx vp test run` 全 2376 テスト通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized error response formats across API endpoints to improve consistency and reliability.
  * Implemented unified error handling utilities for REST and OAuth 2.0 endpoints, ensuring predictable error messages and codes across all API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->