### PR TITLE
リファクタリング: 監査ログ生成ロジックを共通ヘルパー化 (#135)

### DIFF
--- a/workers/id/src/lib/audit.ts
+++ b/workers/id/src/lib/audit.ts
@@ -1,0 +1,90 @@
+import type { Context } from "hono";
+import { createAdminAuditLog, createLogger } from "@0g0-id/shared";
+import type { IdpEnv, TokenPayload } from "@0g0-id/shared";
+import { getClientIp } from "../utils/ip";
+
+/**
+ * 管理者監査ログのアクション種別。
+ * 新しい操作を追加する場合は必ずここに追記すること（タイポ検出のため）。
+ */
+export type AuditAction =
+  | "user.role_change"
+  | "user.ban"
+  | "user.unban"
+  | "user.session_revoked"
+  | "user.sessions_revoked"
+  | "user.delete"
+  | "service.create"
+  | "service.update"
+  | "service.delete"
+  | "service.redirect_uri_added"
+  | "service.redirect_uri_deleted"
+  | "service.secret_rotated"
+  | "service.owner_transferred"
+  | "service.user_access_revoked";
+
+/** 監査ログ対象リソースの種別。 */
+export type AuditTargetType = "user" | "service";
+
+/** 監査ログ生成結果のステータス。 */
+export type AuditStatus = "success" | "failure";
+
+export interface AuditLogInput {
+  action: AuditAction;
+  targetType: AuditTargetType;
+  targetId: string;
+  details?: Record<string, unknown> | null;
+  /** 省略時は "success"。 */
+  status?: AuditStatus;
+}
+
+/** Hono Context が `c.get("user")` で TokenPayload を返せることを要求する Env 制約。 */
+type AuditEnv = { Bindings: IdpEnv; Variables: { user: TokenPayload } };
+
+const auditLogger = createLogger("audit");
+
+/**
+ * 管理者監査ログを記録するヘルパー。
+ *
+ * - `adminUserId` は `c.get("user").sub`（JWT の sub）から自動抽出。
+ * - `ipAddress` は `CF-Connecting-IP` ヘッダから自動抽出。
+ * - 記録失敗は握り潰して `logger.error` に記録する（例外を上位に伝播させない）。
+ *   → 呼び出し側は try/catch を書かずに `await logAdminAudit(c, {...})` するだけで良い。
+ *
+ * @param c Hono Context（`c.get("user")` で TokenPayload が取得可能なこと）
+ * @param input action / targetType / targetId / details / status
+ */
+export async function logAdminAudit<E extends AuditEnv>(
+  c: Context<E>,
+  input: AuditLogInput,
+): Promise<void> {
+  const tokenUser = c.get("user");
+  const ipAddress = getClientIp(c.req.raw);
+  try {
+    await createAdminAuditLog(c.env.DB, {
+      adminUserId: tokenUser.sub,
+      action: input.action,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      details: input.details ?? null,
+      ipAddress,
+      status: input.status ?? "success",
+    });
+  } catch (err) {
+    auditLogger.error("Failed to create admin audit log", {
+      err,
+      action: input.action,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      status: input.status ?? "success",
+    });
+  }
+}
+
+/**
+ * エラーオブジェクトから監査ログ詳細に含めるエラーメッセージを抽出する。
+ * details に `{ error: extractErrorMessage(err) }` の形で混ぜる用途。
+ */
+export function extractErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Unknown error";
+}

--- a/workers/id/src/routes/services.ts
+++ b/workers/id/src/routes/services.ts
@@ -22,7 +22,6 @@ import {
   countUsersAuthorizedForService,
   revokeUserServiceTokens,
   revokeAllServiceTokens,
-  createAdminAuditLog,
   parsePagination,
   UUID_RE,
   uuidParamMiddleware,
@@ -41,7 +40,7 @@ import { authMiddleware } from "../middleware/auth";
 import { adminMiddleware } from "../middleware/admin";
 import { csrfMiddleware } from "../middleware/csrf";
 import { parseJsonBody } from "@0g0-id/shared";
-import { getClientIp } from "../utils/ip";
+import { logAdminAudit } from "../lib/audit";
 
 type Variables = { user: TokenPayload };
 
@@ -192,19 +191,12 @@ app.post("/", authMiddleware, adminMiddleware, csrfMiddleware, async (c) => {
     return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
   }
 
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "service.create",
-      targetType: "service",
-      targetId: service.id,
-      details: { name: service.name, allowed_scopes: body.allowed_scopes ?? ["profile", "email"] },
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    servicesLogger.error("[services] Failed to create audit log for service.create", err);
-  }
+  await logAdminAudit(c, {
+    action: "service.create",
+    targetType: "service",
+    targetId: service.id,
+    details: { name: service.name, allowed_scopes: body.allowed_scopes ?? ["profile", "email"] },
+  });
 
   // client_secretは作成時のみ返却
   return c.json(
@@ -245,23 +237,15 @@ app.patch("/:id", authMiddleware, adminMiddleware, csrfMiddleware, async (c) => 
     return c.json({ error: { code: "NOT_FOUND", message: "Service not found" } }, 404);
   }
 
-  const tokenUser = c.get("user");
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "service.update",
-      targetType: "service",
-      targetId: serviceId,
-      details: {
-        ...(name !== undefined ? { name } : {}),
-        ...(allowed_scopes !== undefined ? { allowed_scopes } : {}),
-      },
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    servicesLogger.error("[services] Failed to create audit log for service.update", err);
-  }
+  await logAdminAudit(c, {
+    action: "service.update",
+    targetType: "service",
+    targetId: serviceId,
+    details: {
+      ...(name !== undefined ? { name } : {}),
+      ...(allowed_scopes !== undefined ? { allowed_scopes } : {}),
+    },
+  });
 
   return c.json({
     data: {
@@ -289,8 +273,6 @@ app.delete("/:id", authMiddleware, adminMiddleware, csrfMiddleware, async (c) =>
     return c.json({ error: { code: "NOT_FOUND", message: "Service not found" } }, 404);
   }
 
-  const tokenUser = c.get("user");
-
   // サービス削除前に全ユーザーのアクティブトークンを失効させる
   let revokedCount: number;
   try {
@@ -312,19 +294,12 @@ app.delete("/:id", authMiddleware, adminMiddleware, csrfMiddleware, async (c) =>
     return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
   }
 
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "service.delete",
-      targetType: "service",
-      targetId: serviceId,
-      details: { name: service.name, revoked_token_count: revokedCount },
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    servicesLogger.error("[services] Failed to create audit log for service.delete", err);
-  }
+  await logAdminAudit(c, {
+    action: "service.delete",
+    targetType: "service",
+    targetId: serviceId,
+    details: { name: service.name, revoked_token_count: revokedCount },
+  });
 
   return c.body(null, 204);
 });
@@ -384,23 +359,12 @@ app.post("/:id/redirect-uris", authMiddleware, adminMiddleware, csrfMiddleware, 
     return c.json({ error: { code: "CONFLICT", message: "Redirect URI already exists" } }, 409);
   }
 
-  const tokenUser = c.get("user");
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "service.redirect_uri_added",
-      targetType: "service",
-      targetId: serviceId,
-      details: { uri: normalized },
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    servicesLogger.error(
-      "[services] Failed to create audit log for service.redirect_uri_added",
-      err,
-    );
-  }
+  await logAdminAudit(c, {
+    action: "service.redirect_uri_added",
+    targetType: "service",
+    targetId: serviceId,
+    details: { uri: normalized },
+  });
 
   return c.json({ data: uri }, 201);
 });
@@ -433,19 +397,11 @@ app.post("/:id/rotate-secret", authMiddleware, adminMiddleware, csrfMiddleware, 
     return c.json({ error: { code: "NOT_FOUND", message: "Service not found" } }, 404);
   }
 
-  const tokenUser = c.get("user");
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "service.secret_rotated",
-      targetType: "service",
-      targetId: serviceId,
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    servicesLogger.error("[services] Failed to create audit log for service.secret_rotated", err);
-  }
+  await logAdminAudit(c, {
+    action: "service.secret_rotated",
+    targetType: "service",
+    targetId: serviceId,
+  });
 
   return c.json({
     data: {
@@ -494,23 +450,12 @@ app.patch("/:id/owner", authMiddleware, adminMiddleware, csrfMiddleware, async (
     return c.json({ error: { code: "NOT_FOUND", message: "Service not found" } }, 404);
   }
 
-  const tokenUser = c.get("user");
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "service.owner_transferred",
-      targetType: "service",
-      targetId: serviceId,
-      details: { from: service.owner_user_id, to: new_owner_user_id },
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    servicesLogger.error(
-      "[services] Failed to create audit log for service.owner_transferred",
-      err,
-    );
-  }
+  await logAdminAudit(c, {
+    action: "service.owner_transferred",
+    targetType: "service",
+    targetId: serviceId,
+    details: { from: service.owner_user_id, to: new_owner_user_id },
+  });
 
   return c.json({
     data: {
@@ -609,23 +554,12 @@ app.delete("/:id/users/:userId", authMiddleware, adminMiddleware, csrfMiddleware
     );
   }
 
-  const tokenUser = c.get("user");
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "service.user_access_revoked",
-      targetType: "service",
-      targetId: serviceId,
-      details: { user_id: userId },
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    servicesLogger.error(
-      "[services] Failed to create audit log for service.user_access_revoked",
-      err,
-    );
-  }
+  await logAdminAudit(c, {
+    action: "service.user_access_revoked",
+    targetType: "service",
+    targetId: serviceId,
+    details: { user_id: userId },
+  });
 
   return c.body(null, 204);
 });
@@ -661,7 +595,6 @@ app.delete(
       return c.json({ error: { code: "NOT_FOUND", message: "Redirect URI not found" } }, 404);
     }
 
-    const tokenUser = c.get("user");
     try {
       await deleteRedirectUri(c.env.DB, uriId, serviceId);
     } catch (err) {
@@ -669,22 +602,12 @@ app.delete(
       return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
     }
 
-    try {
-      await createAdminAuditLog(c.env.DB, {
-        adminUserId: tokenUser.sub,
-        action: "service.redirect_uri_deleted",
-        targetType: "service",
-        targetId: serviceId,
-        details: { uri_id: uriId, uri: redirectUri.uri },
-        ipAddress: getClientIp(c.req.raw),
-        status: "success",
-      });
-    } catch (err) {
-      servicesLogger.error(
-        "[services] Failed to create audit log for service.redirect_uri_deleted",
-        err,
-      );
-    }
+    await logAdminAudit(c, {
+      action: "service.redirect_uri_deleted",
+      targetType: "service",
+      targetId: serviceId,
+      details: { uri_id: uriId, uri: redirectUri.uri },
+    });
 
     return c.body(null, 204);
   },

--- a/workers/id/src/routes/users.ts
+++ b/workers/id/src/routes/users.ts
@@ -23,7 +23,6 @@ import {
   getUserDailyLoginTrends,
   banUser,
   unbanUser,
-  createAdminAuditLog,
   parseDays,
   parsePagination,
   isValidProvider,
@@ -42,7 +41,7 @@ import {
 import { adminMiddleware } from "../middleware/admin";
 import { csrfMiddleware } from "../middleware/csrf";
 import { parseJsonBody } from "@0g0-id/shared";
-import { getClientIp } from "../utils/ip";
+import { logAdminAudit, extractErrorMessage } from "../lib/audit";
 
 const PatchMeSchema = z
   .object({
@@ -694,40 +693,30 @@ app.patch("/:id/role", authMiddleware, adminMiddleware, csrfMiddleware, async (c
     return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
   }
 
-  const ipAddress = getClientIp(c.req.raw);
   let user;
   try {
     user = await updateUserRole(c.env.DB, targetId, role);
     // ロール変更後、既存トークン・MCPセッションを即時失効（権限変更を即反映）
     await revokeUserTokens(c.env.DB, targetId, "security_event");
     await deleteMcpSessionsByUser(c.env.DB, targetId);
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
+    await logAdminAudit(c, {
       action: "user.role_change",
       targetType: "user",
       targetId,
       details: { from: targetUser.role, to: role },
-      ipAddress,
-      status: "success",
     });
   } catch (err) {
-    try {
-      await createAdminAuditLog(c.env.DB, {
-        adminUserId: tokenUser.sub,
-        action: "user.role_change",
-        targetType: "user",
-        targetId,
-        details: {
-          from: targetUser.role,
-          to: role,
-          error: err instanceof Error ? err.message : "Unknown error",
-        },
-        ipAddress,
-        status: "failure",
-      });
-    } catch {
-      /* ログ記録エラーは無視 */
-    }
+    await logAdminAudit(c, {
+      action: "user.role_change",
+      targetType: "user",
+      targetId,
+      details: {
+        from: targetUser.role,
+        to: role,
+        error: extractErrorMessage(err),
+      },
+      status: "failure",
+    });
     throw err;
   }
 
@@ -758,7 +747,6 @@ app.patch("/:id/ban", authMiddleware, adminMiddleware, csrfMiddleware, async (c)
     return c.json({ error: { code: "CONFLICT", message: "User is already banned" } }, 409);
   }
 
-  const ipAddress = getClientIp(c.req.raw);
   let updated;
   try {
     updated = await banUser(c.env.DB, targetId);
@@ -766,34 +754,21 @@ app.patch("/:id/ban", authMiddleware, adminMiddleware, csrfMiddleware, async (c)
     await revokeUserTokens(c.env.DB, targetId, "security_event");
     await deleteMcpSessionsByUser(c.env.DB, targetId);
   } catch (err) {
-    try {
-      await createAdminAuditLog(c.env.DB, {
-        adminUserId: tokenUser.sub,
-        action: "user.ban",
-        targetType: "user",
-        targetId,
-        details: { error: err instanceof Error ? err.message : "Unknown error" },
-        ipAddress,
-        status: "failure",
-      });
-    } catch {
-      /* ログ記録エラーは無視 */
-    }
-    return c.json({ error: { code: "INTERNAL_ERROR", message: "Failed to ban user" } }, 500);
-  }
-
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
+    await logAdminAudit(c, {
       action: "user.ban",
       targetType: "user",
       targetId,
-      ipAddress,
-      status: "success",
+      details: { error: extractErrorMessage(err) },
+      status: "failure",
     });
-  } catch (err) {
-    usersLogger.error("Failed to create audit log for user.ban", err);
+    return c.json({ error: { code: "INTERNAL_ERROR", message: "Failed to ban user" } }, 500);
   }
+
+  await logAdminAudit(c, {
+    action: "user.ban",
+    targetType: "user",
+    targetId,
+  });
 
   return c.json({ data: formatAdminUserSummary(updated) });
 });
@@ -801,7 +776,6 @@ app.patch("/:id/ban", authMiddleware, adminMiddleware, csrfMiddleware, async (c)
 // DELETE /api/users/:id/ban — ユーザー停止を解除（管理者のみ）
 app.delete("/:id/ban", authMiddleware, adminMiddleware, csrfMiddleware, async (c) => {
   const targetId = c.req.param("id");
-  const tokenUser = c.get("user");
 
   const targetUser = await findUserById(c.env.DB, targetId);
   if (!targetUser) {
@@ -812,32 +786,22 @@ app.delete("/:id/ban", authMiddleware, adminMiddleware, csrfMiddleware, async (c
     return c.json({ error: { code: "CONFLICT", message: "User is not banned" } }, 409);
   }
 
-  const ipAddress = getClientIp(c.req.raw);
   let updated;
   try {
     updated = await unbanUser(c.env.DB, targetId);
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
+    await logAdminAudit(c, {
       action: "user.unban",
       targetType: "user",
       targetId,
-      ipAddress,
-      status: "success",
     });
   } catch (err) {
-    try {
-      await createAdminAuditLog(c.env.DB, {
-        adminUserId: tokenUser.sub,
-        action: "user.unban",
-        targetType: "user",
-        targetId,
-        details: { error: err instanceof Error ? err.message : "Unknown error" },
-        ipAddress,
-        status: "failure",
-      });
-    } catch {
-      /* ログ記録エラーは無視 */
-    }
+    await logAdminAudit(c, {
+      action: "user.unban",
+      targetType: "user",
+      targetId,
+      details: { error: extractErrorMessage(err) },
+      status: "failure",
+    });
     throw err;
   }
 
@@ -864,31 +828,23 @@ app.delete("/:id/tokens/:tokenId", authMiddleware, adminMiddleware, csrfMiddlewa
   if (!UUID_RE.test(tokenId)) {
     return c.json({ error: { code: "BAD_REQUEST", message: "Invalid token ID format" } }, 400);
   }
-  const tokenUser = c.get("user");
 
   const targetUser = await findUserById(c.env.DB, targetId);
   if (!targetUser) {
     return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
   }
 
-  const ipAddress = getClientIp(c.req.raw);
   let revoked;
   try {
     revoked = await revokeTokenByIdForUser(c.env.DB, tokenId, targetId, "admin_action");
   } catch (err) {
-    try {
-      await createAdminAuditLog(c.env.DB, {
-        adminUserId: tokenUser.sub,
-        action: "user.session_revoked",
-        targetType: "user",
-        targetId,
-        details: { tokenId, error: err instanceof Error ? err.message : "Unknown error" },
-        ipAddress,
-        status: "failure",
-      });
-    } catch {
-      /* ログ記録エラーは無視 */
-    }
+    await logAdminAudit(c, {
+      action: "user.session_revoked",
+      targetType: "user",
+      targetId,
+      details: { tokenId, error: extractErrorMessage(err) },
+      status: "failure",
+    });
     throw err;
   }
 
@@ -896,14 +852,11 @@ app.delete("/:id/tokens/:tokenId", authMiddleware, adminMiddleware, csrfMiddlewa
     return c.json({ error: { code: "NOT_FOUND", message: "Session not found" } }, 404);
   }
 
-  await createAdminAuditLog(c.env.DB, {
-    adminUserId: tokenUser.sub,
+  await logAdminAudit(c, {
     action: "user.session_revoked",
     targetType: "user",
     targetId,
     details: { tokenId },
-    ipAddress,
-    status: "success",
   });
 
   return c.body(null, 204);
@@ -912,39 +865,28 @@ app.delete("/:id/tokens/:tokenId", authMiddleware, adminMiddleware, csrfMiddlewa
 // DELETE /api/users/:id/tokens — ユーザーの全セッション無効化（管理者のみ）
 app.delete("/:id/tokens", authMiddleware, adminMiddleware, csrfMiddleware, async (c) => {
   const targetId = c.req.param("id");
-  const tokenUser = c.get("user");
 
   const targetUser = await findUserById(c.env.DB, targetId);
   if (!targetUser) {
     return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
   }
 
-  const ipAddress = getClientIp(c.req.raw);
   try {
     await revokeUserTokens(c.env.DB, targetId, "admin_action");
     await deleteMcpSessionsByUser(c.env.DB, targetId);
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
+    await logAdminAudit(c, {
       action: "user.sessions_revoked",
       targetType: "user",
       targetId,
-      ipAddress,
-      status: "success",
     });
   } catch (err) {
-    try {
-      await createAdminAuditLog(c.env.DB, {
-        adminUserId: tokenUser.sub,
-        action: "user.sessions_revoked",
-        targetType: "user",
-        targetId,
-        details: { error: err instanceof Error ? err.message : "Unknown error" },
-        ipAddress,
-        status: "failure",
-      });
-    } catch {
-      /* ログ記録エラーは無視 */
-    }
+    await logAdminAudit(c, {
+      action: "user.sessions_revoked",
+      targetType: "user",
+      targetId,
+      details: { error: extractErrorMessage(err) },
+      status: "failure",
+    });
     throw err;
   }
 
@@ -971,18 +913,11 @@ app.delete("/:id", authMiddleware, adminMiddleware, csrfMiddleware, async (c) =>
     return c.json({ error: deleteError }, 409);
   }
 
-  try {
-    await createAdminAuditLog(c.env.DB, {
-      adminUserId: tokenUser.sub,
-      action: "user.delete",
-      targetType: "user",
-      targetId,
-      ipAddress: getClientIp(c.req.raw),
-      status: "success",
-    });
-  } catch (err) {
-    usersLogger.error("Failed to create audit log for user.delete", err);
-  }
+  await logAdminAudit(c, {
+    action: "user.delete",
+    targetType: "user",
+    targetId,
+  });
 
   return c.body(null, 204);
 });


### PR DESCRIPTION
Closes #135

## Summary
- 新規 `workers/id/src/lib/audit.ts` に `logAdminAudit` ヘルパーを追加
  - `adminUserId` を Context の `tokenUser.sub` から自動抽出
  - `ipAddress` を `CF-Connecting-IP` ヘッダから自動抽出
  - 記録失敗時の `try/catch` はヘルパー内部で吸収（呼び出し側で書かない）
  - `AuditAction` union 型でアクション名のタイポを静的検出
- `workers/id/src/routes/users.ts` の 11 呼び出し、`workers/id/src/routes/services.ts` の 8 呼び出しをヘルパー経由に統一
- DRY 違反と失敗時エラーハンドリングの 3 パターン混在を解消

## 変更差分
- 193 insertions / 245 deletions（純減 52 行）
- 新規 1 ファイル（audit.ts）+ 修正 2 ファイル

## 挙動保全
- `user.ban`: 失敗時 500 返却（throw しない）パターンを維持
- `user.unban`, `user.role_change`, `user.session_revoked`, `user.sessions_revoked`: 失敗時 `throw err` パターンを維持
- 成功/失敗ログの記録順序は旧コードと等価

## Test plan
- [x] `npx vp check` 通過（lint + format + typecheck）
- [x] `npx vp test run` 通過（2376 tests passed）
- [x] code-reviewer エージェントで LGTM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unified audit logging module for systematically capturing admin actions with enhanced error tracking and status reporting.

* **Refactor**
  * Streamlined audit log creation across admin routes by consolidating logging logic and standardizing error message handling for comprehensive audit trail consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->