### PR TITLE
バグ修正: banUser/role_change の副作用をD1 batch()でアトミック化 (#137)

### DIFF
--- a/packages/shared/src/db/users.test.ts
+++ b/packages/shared/src/db/users.test.ts
@@ -20,7 +20,9 @@ import {
   countAdminUsers,
   tryBootstrapAdmin,
   banUser,
+  banUserWithRevocation,
   unbanUser,
+  updateUserRoleWithRevocation,
 } from "./users";
 import type { User } from "../types";
 import { makeD1Mock } from "./test-helpers";
@@ -721,6 +723,84 @@ describe("unbanUser", () => {
     const db = makeD1Mock(baseUser);
     await unbanUser(db, "user-1");
     expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("banned_at = NULL"));
+  });
+});
+
+type BatchD1Mock = D1Database & {
+  batch: ReturnType<typeof vi.fn>;
+  prepare: ReturnType<typeof vi.fn>;
+  _stmt: { bind: ReturnType<typeof vi.fn> };
+};
+
+/** D1 batch() を返せるように makeD1Mock を拡張した軽量ヘルパー */
+function makeBatchD1Mock(updatedUser: User | null): BatchD1Mock {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn().mockResolvedValue(null),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    all: vi.fn().mockResolvedValue({ results: [] }),
+  };
+  const batchResults = [
+    { results: updatedUser ? [updatedUser] : [] },
+    { results: [] },
+    { results: [] },
+  ];
+  const db = {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn().mockResolvedValue(batchResults),
+    _stmt: stmt,
+  };
+  return db as unknown as BatchD1Mock;
+}
+
+describe("banUserWithRevocation", () => {
+  it("batch() で ban/トークン失効/MCPセッション削除を1トランザクションで実行する", async () => {
+    const banned = { ...baseUser, banned_at: "2026-03-24T00:00:00Z" };
+    const db = makeBatchD1Mock(banned);
+    const user = await banUserWithRevocation(db, "user-1");
+    expect(user.banned_at).toBe("2026-03-24T00:00:00Z");
+    expect(db.batch).toHaveBeenCalledTimes(1);
+    // 3つのprepared statementが束ねられている（users更新, refresh_tokens失効, mcp_sessions削除）
+    expect(db.prepare).toHaveBeenCalledTimes(3);
+    const sqls = (db.prepare as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string);
+    expect(sqls[0]).toContain("UPDATE users SET banned_at");
+    expect(sqls[1]).toContain("UPDATE refresh_tokens SET revoked_at");
+    expect(sqls[2]).toContain("DELETE FROM mcp_sessions");
+  });
+
+  it("ユーザーが見つからない場合はエラーを投げる", async () => {
+    const db = makeBatchD1Mock(null);
+    await expect(banUserWithRevocation(db, "not-exist")).rejects.toThrow("User not found");
+  });
+
+  it("revoked_reason = 'security_event' で失効する", async () => {
+    const banned = { ...baseUser, banned_at: "2026-03-24T00:00:00Z" };
+    const db = makeBatchD1Mock(banned);
+    await banUserWithRevocation(db, "user-1");
+    // 2番目（refresh_tokens）のbindに "security_event" が渡される
+    expect(db._stmt.bind).toHaveBeenCalledWith("security_event", "user-1");
+  });
+});
+
+describe("updateUserRoleWithRevocation", () => {
+  it("batch() でロール変更/トークン失効/MCPセッション削除を1トランザクションで実行する", async () => {
+    const promoted = { ...baseUser, role: "admin" as const };
+    const db = makeBatchD1Mock(promoted);
+    const user = await updateUserRoleWithRevocation(db, "user-1", "admin");
+    expect(user.role).toBe("admin");
+    expect(db.batch).toHaveBeenCalledTimes(1);
+    expect(db.prepare).toHaveBeenCalledTimes(3);
+    const sqls = (db.prepare as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string);
+    expect(sqls[0]).toContain("UPDATE users SET role");
+    expect(sqls[1]).toContain("UPDATE refresh_tokens SET revoked_at");
+    expect(sqls[2]).toContain("DELETE FROM mcp_sessions");
+  });
+
+  it("ユーザーが見つからない場合はエラーを投げる", async () => {
+    const db = makeBatchD1Mock(null);
+    await expect(updateUserRoleWithRevocation(db, "not-exist", "admin")).rejects.toThrow(
+      "User not found",
+    );
   });
 });
 

--- a/packages/shared/src/db/users.ts
+++ b/packages/shared/src/db/users.ts
@@ -250,6 +250,13 @@ export async function upsertXUser(
   });
 }
 
+/**
+ * ユーザーの role だけを更新するロウレベル関数。
+ *
+ * ⚠️ 本番コードでは {@link updateUserRoleWithRevocation} を使うこと。
+ * ロール変更時は旧権限で発行された既存トークン・MCPセッションも同時に失効させる
+ * 必要があるが、この関数はその副作用を伴わないため単独利用は危険。
+ */
 export async function updateUserRole(
   db: D1Database,
   userId: string,
@@ -261,6 +268,37 @@ export async function updateUserRole(
     )
     .bind(role, userId)
     .first<User>();
+  if (!user) throw new Error("User not found");
+  return user;
+}
+
+/**
+ * ロール変更 + 全リフレッシュトークン失効 + 全MCPセッション削除 を
+ * D1 batch() で単一トランザクションとして実行する。
+ *
+ * ⚠️ 呼び出し前に対象ユーザーの存在チェックと、同値ロールでないことの
+ * チェックを必ず行うこと。同値ロールで呼ぶと対象ユーザーの全セッションが
+ * 無駄に失効する。
+ */
+export async function updateUserRoleWithRevocation(
+  db: D1Database,
+  userId: string,
+  role: "user" | "admin",
+): Promise<User> {
+  const results = await db.batch([
+    db
+      .prepare(
+        `UPDATE users SET role = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ? RETURNING *`,
+      )
+      .bind(role, userId),
+    db
+      .prepare(
+        `UPDATE refresh_tokens SET revoked_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), revoked_reason = ? WHERE user_id = ? AND revoked_at IS NULL`,
+      )
+      .bind("security_event", userId),
+    db.prepare(`DELETE FROM mcp_sessions WHERE user_id = ?`).bind(userId),
+  ]);
+  const user = results[0]?.results?.[0] as User | undefined;
   if (!user) throw new Error("User not found");
   return user;
 }
@@ -439,6 +477,13 @@ export async function unlinkProvider(
   if ((result.meta.changes ?? 0) === 0) throw new Error("User not found");
 }
 
+/**
+ * ユーザーの banned_at だけを更新するロウレベル関数。
+ *
+ * ⚠️ 本番コードでは {@link banUserWithRevocation} を使うこと。
+ * この関数はトークン失効・MCPセッション削除を行わないため、単独で使うと
+ * 「ban状態だが旧トークンは有効」という不整合を生む。
+ */
 export async function banUser(db: D1Database, userId: string): Promise<User> {
   const user = await db
     .prepare(
@@ -446,6 +491,36 @@ export async function banUser(db: D1Database, userId: string): Promise<User> {
     )
     .bind(userId)
     .first<User>();
+  if (!user) throw new Error("User not found");
+  return user;
+}
+
+/**
+ * ユーザー停止 + 全リフレッシュトークン失効 + 全MCPセッション削除 を
+ * D1 batch() で単一トランザクションとして実行する。
+ *
+ * いずれかが失敗した場合は全体がロールバックされ、ban状態だけ設定されてトークンが残る
+ * といった中途半端な状態を防ぐ。
+ *
+ * ⚠️ 呼び出し前に対象ユーザーの存在チェックを行うこと。batch() 内の refresh_tokens /
+ * mcp_sessions 操作は userId が存在しなくても（行が0件なだけで）成功してしまうため、
+ * 「ユーザー不在だがトークン/セッションはクリア済み」という状態になり得る。
+ */
+export async function banUserWithRevocation(db: D1Database, userId: string): Promise<User> {
+  const results = await db.batch([
+    db
+      .prepare(
+        `UPDATE users SET banned_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ? RETURNING *`,
+      )
+      .bind(userId),
+    db
+      .prepare(
+        `UPDATE refresh_tokens SET revoked_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), revoked_reason = ? WHERE user_id = ? AND revoked_at IS NULL`,
+      )
+      .bind("security_event", userId),
+    db.prepare(`DELETE FROM mcp_sessions WHERE user_id = ?`).bind(userId),
+  ]);
+  const user = results[0]?.results?.[0] as User | undefined;
   if (!user) throw new Error("User not found");
   return user;
 }

--- a/workers/id/src/routes/users.test.ts
+++ b/workers/id/src/routes/users.test.ts
@@ -14,6 +14,7 @@ vi.mock("@0g0-id/shared", async (importOriginal) => {
     countUsers: vi.fn(),
     updateUserProfile: vi.fn(),
     updateUserRole: vi.fn(),
+    updateUserRoleWithRevocation: vi.fn(),
     deleteUser: vi.fn(),
     listUserConnections: vi.fn(),
     revokeUserServiceTokens: vi.fn(),
@@ -30,6 +31,7 @@ vi.mock("@0g0-id/shared", async (importOriginal) => {
     getUserLoginProviderStats: vi.fn(),
     getUserDailyLoginTrends: vi.fn(),
     banUser: vi.fn(),
+    banUserWithRevocation: vi.fn(),
     unbanUser: vi.fn(),
     createAdminAuditLog: vi.fn(),
     UUID_RE: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
@@ -77,7 +79,7 @@ import {
   listUsers,
   countUsers,
   updateUserProfile,
-  updateUserRole,
+  updateUserRoleWithRevocation,
   deleteUser,
   listUserConnections,
   revokeUserServiceTokens,
@@ -92,7 +94,7 @@ import {
   getLoginEventsByUserId,
   getUserLoginProviderStats,
   getUserDailyLoginTrends,
-  banUser,
+  banUserWithRevocation,
   unbanUser,
   verifyAccessToken,
   type UserFilter,
@@ -906,7 +908,7 @@ describe("PATCH /api/users/:id/role", () => {
     vi.resetAllMocks();
     vi.mocked(verifyAccessToken).mockResolvedValue(mockAdminPayload);
     vi.mocked(findUserById).mockResolvedValue(mockUser);
-    vi.mocked(updateUserRole).mockResolvedValue({ ...mockUser, role: "admin" });
+    vi.mocked(updateUserRoleWithRevocation).mockResolvedValue({ ...mockUser, role: "admin" });
     vi.mocked(revokeUserTokens).mockResolvedValue();
   });
 
@@ -976,16 +978,18 @@ describe("PATCH /api/users/:id/role", () => {
     expect(body.error.code).toBe("BAD_REQUEST");
   });
 
-  it("ロール変更後に既存トークンを失効させる", async () => {
+  it("ロール変更時にbatchで既存トークン失効・MCPセッション削除が同時に実行される", async () => {
     await sendRequest(app, "/api/users/00000000-0000-0000-0000-000000000004/role", {
       method: "PATCH",
       body: { role: "admin" },
       origin: "https://admin.0g0.xyz",
     });
-    expect(vi.mocked(revokeUserTokens)).toHaveBeenCalledWith(
+    // updateUserRoleWithRevocation は内部で D1 batch() により
+    // users.role 更新 + refresh_tokens 失効 + mcp_sessions 削除 を 1トランザクションで実行する
+    expect(vi.mocked(updateUserRoleWithRevocation)).toHaveBeenCalledWith(
       expect.anything(),
       "00000000-0000-0000-0000-000000000004",
-      "security_event",
+      "admin",
     );
   });
 });
@@ -2418,12 +2422,11 @@ describe("PATCH /api/users/:id/ban — ユーザー停止", () => {
       ...mockUser,
       id: "00000000-0000-0000-0000-000000000003",
     });
-    vi.mocked(banUser).mockResolvedValue({
+    vi.mocked(banUserWithRevocation).mockResolvedValue({
       ...mockUser,
       id: "00000000-0000-0000-0000-000000000003",
       banned_at: "2026-03-24T00:00:00Z",
     });
-    vi.mocked(revokeUserTokens).mockResolvedValue(undefined);
   });
 
   it("対象ユーザーを停止し200を返す", async () => {
@@ -2434,11 +2437,22 @@ describe("PATCH /api/users/:id/ban — ユーザー停止", () => {
     expect(res.status).toBe(200);
     const body = await res.json<{ data: { banned_at: string } }>();
     expect(body.data.banned_at).toBe("2026-03-24T00:00:00Z");
-    expect(vi.mocked(revokeUserTokens)).toHaveBeenCalledWith(
+    // batch() 内でトークン失効・MCPセッション削除も同時にアトミック実行される
+    expect(vi.mocked(banUserWithRevocation)).toHaveBeenCalledWith(
       expect.anything(),
       "00000000-0000-0000-0000-000000000003",
-      "security_event",
     );
+  });
+
+  it("banUserWithRevocation() が失敗した場合 → 500とfailure監査ログを返す", async () => {
+    vi.mocked(banUserWithRevocation).mockRejectedValue(new Error("D1 batch failed"));
+    const res = await sendRequest(app, "/api/users/00000000-0000-0000-0000-000000000003/ban", {
+      method: "PATCH",
+      origin: "https://id.0g0.xyz",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json<{ error: { code: string } }>();
+    expect(body.error.code).toBe("INTERNAL_ERROR");
   });
 
   it("自分自身を停止しようとした場合 → 403を返す", async () => {

--- a/workers/id/src/routes/users.ts
+++ b/workers/id/src/routes/users.ts
@@ -5,7 +5,7 @@ import {
   listUsers,
   countUsers,
   updateUserProfile,
-  updateUserRole,
+  updateUserRoleWithRevocation,
   deleteUser,
   listUserConnections,
   revokeUserServiceTokens,
@@ -21,7 +21,7 @@ import {
   getLoginEventsByUserId,
   getUserLoginProviderStats,
   getUserDailyLoginTrends,
-  banUser,
+  banUserWithRevocation,
   unbanUser,
   parseDays,
   parsePagination,
@@ -693,18 +693,15 @@ app.patch("/:id/role", authMiddleware, adminMiddleware, csrfMiddleware, async (c
     return c.json({ error: { code: "NOT_FOUND", message: "User not found" } }, 404);
   }
 
+  // 同値ロールへの変更は noop（誤って全セッション・MCPを失効させない）
+  if (targetUser.role === role) {
+    return c.json({ data: formatAdminUserSummary(targetUser) });
+  }
+
   let user;
   try {
-    user = await updateUserRole(c.env.DB, targetId, role);
-    // ロール変更後、既存トークン・MCPセッションを即時失効（権限変更を即反映）
-    await revokeUserTokens(c.env.DB, targetId, "security_event");
-    await deleteMcpSessionsByUser(c.env.DB, targetId);
-    await logAdminAudit(c, {
-      action: "user.role_change",
-      targetType: "user",
-      targetId,
-      details: { from: targetUser.role, to: role },
-    });
+    // ロール変更 + トークン失効 + MCPセッション削除 を D1 batch() でアトミックに実行
+    user = await updateUserRoleWithRevocation(c.env.DB, targetId, role);
   } catch (err) {
     await logAdminAudit(c, {
       action: "user.role_change",
@@ -717,8 +714,18 @@ app.patch("/:id/role", authMiddleware, adminMiddleware, csrfMiddleware, async (c
       },
       status: "failure",
     });
-    throw err;
+    return c.json(
+      { error: { code: "INTERNAL_ERROR", message: "Failed to change user role" } },
+      500,
+    );
   }
+
+  await logAdminAudit(c, {
+    action: "user.role_change",
+    targetType: "user",
+    targetId,
+    details: { from: targetUser.role, to: role },
+  });
 
   return c.json({ data: formatAdminUserSummary(user) });
 });
@@ -749,10 +756,8 @@ app.patch("/:id/ban", authMiddleware, adminMiddleware, csrfMiddleware, async (c)
 
   let updated;
   try {
-    updated = await banUser(c.env.DB, targetId);
-    // 停止と同時に全セッション・MCPセッション失効
-    await revokeUserTokens(c.env.DB, targetId, "security_event");
-    await deleteMcpSessionsByUser(c.env.DB, targetId);
+    // 停止 + トークン失効 + MCPセッション削除 を D1 batch() でアトミックに実行
+    updated = await banUserWithRevocation(c.env.DB, targetId);
   } catch (err) {
     await logAdminAudit(c, {
       action: "user.ban",

--- a/workers/mcp/src/tools/users.test.ts
+++ b/workers/mcp/src/tools/users.test.ts
@@ -4,10 +4,10 @@ vi.mock("@0g0-id/shared", () => ({
   listUsers: vi.fn(),
   countUsers: vi.fn(),
   findUserById: vi.fn(),
-  banUser: vi.fn(),
+  banUserWithRevocation: vi.fn(),
   unbanUser: vi.fn(),
   deleteUser: vi.fn(),
-  updateUserRole: vi.fn(),
+  updateUserRoleWithRevocation: vi.fn(),
   getUserProviders: vi.fn(),
   getLoginEventsByUserId: vi.fn(),
   getUserLoginProviderStats: vi.fn(),
@@ -24,10 +24,10 @@ import {
   listUsers,
   countUsers,
   findUserById,
-  banUser,
+  banUserWithRevocation,
   unbanUser,
   deleteUser,
-  updateUserRole,
+  updateUserRoleWithRevocation,
   getUserProviders,
   getLoginEventsByUserId,
   getUserLoginProviderStats,
@@ -198,7 +198,7 @@ describe("banUserTool", () => {
   it("ユーザーをBANし監査ログを記録する", async () => {
     const bannedUser = { ...mockUser, banned_at: "2024-06-01T00:00:00Z" };
     vi.mocked(findUserById).mockResolvedValue(mockUser);
-    vi.mocked(banUser).mockResolvedValue(bannedUser as never);
+    vi.mocked(banUserWithRevocation).mockResolvedValue(bannedUser as never);
 
     const result = await banUserTool.handler({ user_id: "user-1" }, mockContext);
 
@@ -224,7 +224,7 @@ describe("banUserTool", () => {
 
     const result = await banUserTool.handler({ user_id: "nonexistent" }, mockContext);
     expect(result.isError).toBe(true);
-    expect(vi.mocked(banUser)).not.toHaveBeenCalled();
+    expect(vi.mocked(banUserWithRevocation)).not.toHaveBeenCalled();
   });
 });
 
@@ -702,7 +702,10 @@ describe("getUserAuthorizedServicesTool", () => {
 describe("updateUserRoleTool", () => {
   it("ユーザーのロールを user → admin に変更し監査ログを記録する", async () => {
     vi.mocked(findUserById).mockResolvedValue({ ...mockUser, role: "user" });
-    vi.mocked(updateUserRole).mockResolvedValue({ ...mockUser, role: "admin" } as never);
+    vi.mocked(updateUserRoleWithRevocation).mockResolvedValue({
+      ...mockUser,
+      role: "admin",
+    } as never);
 
     const result = await updateUserRoleTool.handler(
       { user_id: "user-1", role: "admin" },
@@ -712,7 +715,11 @@ describe("updateUserRoleTool", () => {
     expect(result.isError).toBeUndefined();
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.role).toBe("admin");
-    expect(vi.mocked(updateUserRole)).toHaveBeenCalledWith(mockContext.db, "user-1", "admin");
+    expect(vi.mocked(updateUserRoleWithRevocation)).toHaveBeenCalledWith(
+      mockContext.db,
+      "user-1",
+      "admin",
+    );
     expect(vi.mocked(createAdminAuditLog)).toHaveBeenCalledWith(
       mockContext.db,
       expect.objectContaining({
@@ -733,7 +740,7 @@ describe("updateUserRoleTool", () => {
 
     expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toContain("既に");
-    expect(vi.mocked(updateUserRole)).not.toHaveBeenCalled();
+    expect(vi.mocked(updateUserRoleWithRevocation)).not.toHaveBeenCalled();
   });
 
   it("user_id未指定はエラー", async () => {
@@ -761,6 +768,6 @@ describe("updateUserRoleTool", () => {
       mockContext,
     );
     expect(result.isError).toBe(true);
-    expect(vi.mocked(updateUserRole)).not.toHaveBeenCalled();
+    expect(vi.mocked(updateUserRoleWithRevocation)).not.toHaveBeenCalled();
   });
 });

--- a/workers/mcp/src/tools/users.ts
+++ b/workers/mcp/src/tools/users.ts
@@ -3,10 +3,10 @@ import {
   findUserById,
   listUsers,
   countUsers,
-  banUser,
+  banUserWithRevocation,
   unbanUser,
   deleteUser,
-  updateUserRole,
+  updateUserRoleWithRevocation,
   getUserProviders,
   getLoginEventsByUserId,
   getUserLoginProviderStats,
@@ -122,9 +122,8 @@ export const banUserTool: McpTool = {
       return { content: [{ type: "text", text: "ユーザーが見つかりません" }], isError: true };
     }
 
-    const user = await banUser(context.db, userId);
-    await revokeUserTokens(context.db, userId, "security_event");
-    await deleteMcpSessionsByUser(context.db, userId);
+    // BAN + 全トークン失効 + MCPセッション削除 を D1 batch() でアトミックに実行
+    const user = await banUserWithRevocation(context.db, userId);
     await createAdminAuditLog(context.db, {
       adminUserId: context.userId,
       action: "user.ban",
@@ -539,7 +538,9 @@ export const updateUserRoleTool: McpTool = {
       };
     }
 
-    const updated = await updateUserRole(context.db, userId, role);
+    // ロール変更 + 全トークン失効 + MCPセッション削除 を D1 batch() でアトミックに実行
+    // （権限変更を即座に反映するための既存セッション失効 — REST route と整合）
+    const updated = await updateUserRoleWithRevocation(context.db, userId, role);
 
     await createAdminAuditLog(context.db, {
       adminUserId: context.userId,


### PR DESCRIPTION
## Summary

- `banUser` / `updateUserRole` + `revokeUserTokens` + `deleteMcpSessionsByUser` の逐次3ステップを D1 `batch()` で単一トランザクション化
- REST (workers/id) と MCP (workers/mcp) の両方の呼び出し箇所を新関数 `banUserWithRevocation` / `updateUserRoleWithRevocation` に差し替え
- role route に同値ロール判定（admin→admin の誤送信で全セッションが無駄に失効するのを防止）
- role route のエラー処理を ban route と揃え、500 をハンドリングして返す
- 旧 `banUser` / `updateUserRole` に JSDoc 警告を追加し、新関数への誘導を明示

## 挙動変更の注意

**MCP Worker の `update_user_role` ツール** — これまで `revokeUserTokens` / `deleteMcpSessionsByUser` を呼んでいなかったが、新関数化に伴い REST route と同様に**ロール変更時に全セッションが失効するようになる**。権限変更の即時反映としては正しい挙動（REST 側はもともとそうしていた）。

## スコープ外（follow-up 候補）

以下3箇所にも同じ「逐次 `revokeUserTokens → deleteMcpSessionsByUser`」パターンが残っているが、Issue #137 のスコープ（ban/role の副作用ロールバック）から外れるため今回は見送り:

- `workers/id/src/routes/users.ts:143-144` (`performUserDeletion`)
- `workers/id/src/routes/users.ts:527-528` (`/me/tokens` DELETE 全セッション失効)
- `workers/id/src/routes/users.ts:871-872` (`/:id/tokens` DELETE 管理者による一括失効)

## Test plan

- [x] `npx vp check` — lint・format・型チェック通過
- [x] `npx vp test run` — 全 2382 テスト通過（新規に `banUserWithRevocation` / `updateUserRoleWithRevocation` の単体テスト 5件 + ban失敗時の監査ログ検証を追加）

Close #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * User role changes and account bans now execute as atomic transactions, automatically revoking active tokens and clearing associated sessions in a single coordinated operation for enhanced system reliability and data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->