### PR TITLE
セキュリティ対応: BFFセッションのリモート失効とTTL短縮 (#139)

### DIFF
--- a/migrations/0023_bff_sessions.sql
+++ b/migrations/0023_bff_sessions.sql
@@ -1,0 +1,22 @@
+-- BFF セッション管理テーブル
+-- BFF (user.0g0.xyz / admin.0g0.xyz) のセッション Cookie を D1 上で任意失効可能にする。
+-- Cookie 自体は AES-GCM 暗号化されているが、クライアント側で30日保持されるため
+-- 端末マルウェア等で Cookie が漏洩した場合の強制失効手段がなかった。
+-- このテーブルに session_id を持たせて BFF リクエスト毎に有効性を検証することで、
+-- リモート失効（管理画面・ログアウト・全デバイスサインアウト）を可能にする。
+
+CREATE TABLE IF NOT EXISTS bff_sessions (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  revoked_at INTEGER,
+  revoked_reason TEXT,
+  user_agent TEXT,
+  ip TEXT,
+  bff_origin TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_bff_sessions_user_id ON bff_sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_bff_sessions_expires_at ON bff_sessions (expires_at);

--- a/packages/shared/src/db/bff-sessions.test.ts
+++ b/packages/shared/src/db/bff-sessions.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vite-plus/test";
+import {
+  createBffSession,
+  findActiveBffSession,
+  revokeBffSession,
+  revokeAllBffSessionsByUserId,
+  cleanupStaleBffSessions,
+  countActiveBffSessionsByUserId,
+} from "./bff-sessions";
+import { makeD1Mock } from "./test-helpers";
+
+describe("createBffSession", () => {
+  it("INSERT INTO bff_sessions を実行する", async () => {
+    const db = makeD1Mock();
+    await createBffSession(db, {
+      id: "00000000-0000-0000-0000-000000000001",
+      userId: "user-1",
+      expiresAt: Math.floor(Date.now() / 1000) + 86400,
+      bffOrigin: "https://user.0g0.xyz",
+      userAgent: "Mozilla/5.0",
+      ip: "203.0.113.1",
+    });
+    expect(db.prepare).toHaveBeenCalledWith(expect.stringContaining("INSERT INTO bff_sessions"));
+    expect((db._stmt as unknown as { run: ReturnType<typeof vi.fn> }).run).toHaveBeenCalledOnce();
+  });
+
+  it("user_agent / ip が未指定でも null でバインドされる", async () => {
+    const db = makeD1Mock();
+    await createBffSession(db, {
+      id: "00000000-0000-0000-0000-000000000002",
+      userId: "user-1",
+      expiresAt: 1234567890,
+      bffOrigin: "https://admin.0g0.xyz",
+    });
+    const bindCalls = (db._stmt.bind as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(bindCalls).toContain(null);
+  });
+});
+
+describe("findActiveBffSession", () => {
+  it("有効なセッションを返す", async () => {
+    const row = {
+      id: "s-1",
+      user_id: "user-1",
+      created_at: 1000,
+      expires_at: 9999999999,
+      revoked_at: null,
+      revoked_reason: null,
+      user_agent: null,
+      ip: null,
+      bff_origin: "https://user.0g0.xyz",
+    };
+    const db = makeD1Mock(row);
+    const result = await findActiveBffSession(db, "s-1");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("s-1");
+    // SQL には revoked_at IS NULL と expires_at > ? が含まれる
+    const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain("revoked_at IS NULL");
+    expect(sql).toContain("expires_at >");
+  });
+
+  it("存在しない場合は null", async () => {
+    const db = makeD1Mock(null);
+    const result = await findActiveBffSession(db, "missing");
+    expect(result).toBeNull();
+  });
+});
+
+describe("revokeBffSession", () => {
+  it("UPDATE ... revoked_at = ? を実行する", async () => {
+    const db = makeD1Mock();
+    await revokeBffSession(db, "s-1", "user_logout");
+    const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain("UPDATE bff_sessions");
+    expect(sql).toContain("revoked_at = ?");
+    expect(sql).toContain("revoked_at IS NULL");
+  });
+});
+
+describe("revokeAllBffSessionsByUserId", () => {
+  it("changes 数を返す", async () => {
+    const db = makeD1Mock(null, [], 3);
+    const count = await revokeAllBffSessionsByUserId(db, "user-1", "security_event");
+    expect(count).toBe(3);
+  });
+});
+
+describe("cleanupStaleBffSessions", () => {
+  it("DELETE ... WHERE expires_at < ? OR revoked_at < ? を実行する", async () => {
+    const db = makeD1Mock();
+    await cleanupStaleBffSessions(db);
+    const sql = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(sql).toContain("DELETE FROM bff_sessions");
+    expect(sql).toContain("expires_at <");
+    expect(sql).toContain("revoked_at");
+  });
+});
+
+describe("countActiveBffSessionsByUserId", () => {
+  it("COUNT(*) を返す", async () => {
+    const db = makeD1Mock({ cnt: 2 });
+    const count = await countActiveBffSessionsByUserId(db, "user-1");
+    expect(count).toBe(2);
+  });
+
+  it("行なしの場合は 0", async () => {
+    const db = makeD1Mock(null);
+    const count = await countActiveBffSessionsByUserId(db, "user-1");
+    expect(count).toBe(0);
+  });
+});

--- a/packages/shared/src/db/bff-sessions.ts
+++ b/packages/shared/src/db/bff-sessions.ts
@@ -1,0 +1,152 @@
+/**
+ * BFF セッション管理（bff_sessions テーブル）
+ *
+ * BFF（user.0g0.xyz / admin.0g0.xyz）の暗号化済みセッション Cookie を
+ * サーバー側で任意失効可能にするための永続レイヤ。
+ *
+ * 呼び出しは ID Worker の内部ルート（/internal/bff-sessions/*）経由のみを想定。
+ * BFF Worker は D1 バインディングを持たず、Service Binding で ID Worker に委譲する。
+ */
+
+export interface BffSessionRecord {
+  id: string;
+  user_id: string;
+  created_at: number;
+  expires_at: number;
+  revoked_at: number | null;
+  revoked_reason: string | null;
+  user_agent: string | null;
+  ip: string | null;
+  bff_origin: string;
+}
+
+export interface CreateBffSessionInput {
+  id: string;
+  userId: string;
+  expiresAt: number;
+  bffOrigin: string;
+  userAgent?: string | null;
+  ip?: string | null;
+}
+
+/**
+ * BFF セッションを作成する。id（UUID 等）・user_id・expires_at（unix秒）が必須。
+ */
+export async function createBffSession(
+  db: D1Database,
+  input: CreateBffSessionInput,
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await db
+    .prepare(
+      `INSERT INTO bff_sessions (id, user_id, created_at, expires_at, user_agent, ip, bff_origin)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      input.id,
+      input.userId,
+      now,
+      input.expiresAt,
+      input.userAgent ?? null,
+      input.ip ?? null,
+      input.bffOrigin,
+    )
+    .run();
+}
+
+/**
+ * 有効な（未失効・未期限切れ）BFF セッションを返す。
+ * 失効済み・期限切れ・存在しない場合は null。
+ */
+export async function findActiveBffSession(
+  db: D1Database,
+  sessionId: string,
+): Promise<BffSessionRecord | null> {
+  const now = Math.floor(Date.now() / 1000);
+  const row = await db
+    .prepare(
+      `SELECT id, user_id, created_at, expires_at, revoked_at, revoked_reason,
+              user_agent, ip, bff_origin
+         FROM bff_sessions
+        WHERE id = ? AND revoked_at IS NULL AND expires_at > ?`,
+    )
+    .bind(sessionId, now)
+    .first<BffSessionRecord>();
+  return row ?? null;
+}
+
+/**
+ * 単一のBFFセッションを失効させる。既に失効済みの場合は no-op。
+ */
+export async function revokeBffSession(
+  db: D1Database,
+  sessionId: string,
+  reason: string,
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await db
+    .prepare(
+      `UPDATE bff_sessions
+          SET revoked_at = ?, revoked_reason = ?
+        WHERE id = ? AND revoked_at IS NULL`,
+    )
+    .bind(now, reason, sessionId)
+    .run();
+}
+
+/**
+ * ユーザーの全BFFセッションを失効させる（全デバイスサインアウト）。
+ * 失効件数を返す。
+ */
+export async function revokeAllBffSessionsByUserId(
+  db: D1Database,
+  userId: string,
+  reason: string,
+): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+  const result = await db
+    .prepare(
+      `UPDATE bff_sessions
+          SET revoked_at = ?, revoked_reason = ?
+        WHERE user_id = ? AND revoked_at IS NULL`,
+    )
+    .bind(now, reason, userId)
+    .run();
+  return result.meta?.changes ?? 0;
+}
+
+/**
+ * 期限切れ・失効済みで一定期間経過した BFF セッションを削除する（日次cron想定）。
+ * 失効後7日保持で削除。
+ */
+export async function cleanupStaleBffSessions(db: D1Database): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  const graceSeconds = 7 * 24 * 60 * 60;
+  await db
+    .prepare(
+      `DELETE FROM bff_sessions
+        WHERE expires_at < ?
+           OR (revoked_at IS NOT NULL AND revoked_at < ?)`,
+    )
+    .bind(now, now - graceSeconds)
+    .run();
+}
+
+/**
+ * ユーザーの有効な BFF セッション件数を取得する（セキュリティダッシュボード向け）。
+ */
+export async function countActiveBffSessionsByUserId(
+  db: D1Database,
+  userId: string,
+): Promise<number> {
+  const now = Math.floor(Date.now() / 1000);
+  const row = await db
+    .prepare(
+      `SELECT COUNT(*) AS cnt
+         FROM bff_sessions
+        WHERE user_id = ? AND revoked_at IS NULL AND expires_at > ?`,
+    )
+    .bind(userId, now)
+    .first<{ cnt: number }>();
+  return row?.cnt ?? 0;
+}

--- a/packages/shared/src/db/users.test.ts
+++ b/packages/shared/src/db/users.test.ts
@@ -744,6 +744,7 @@ function makeBatchD1Mock(updatedUser: User | null): BatchD1Mock {
     { results: updatedUser ? [updatedUser] : [] },
     { results: [] },
     { results: [] },
+    { results: [] },
   ];
   const db = {
     prepare: vi.fn().mockReturnValue(stmt),
@@ -760,12 +761,13 @@ describe("banUserWithRevocation", () => {
     const user = await banUserWithRevocation(db, "user-1");
     expect(user.banned_at).toBe("2026-03-24T00:00:00Z");
     expect(db.batch).toHaveBeenCalledTimes(1);
-    // 3つのprepared statementが束ねられている（users更新, refresh_tokens失効, mcp_sessions削除）
-    expect(db.prepare).toHaveBeenCalledTimes(3);
+    // 4つのprepared statementが束ねられている（users更新, refresh_tokens失効, mcp_sessions削除, bff_sessions失効）
+    expect(db.prepare).toHaveBeenCalledTimes(4);
     const sqls = (db.prepare as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string);
     expect(sqls[0]).toContain("UPDATE users SET banned_at");
     expect(sqls[1]).toContain("UPDATE refresh_tokens SET revoked_at");
     expect(sqls[2]).toContain("DELETE FROM mcp_sessions");
+    expect(sqls[3]).toContain("UPDATE bff_sessions SET revoked_at");
   });
 
   it("ユーザーが見つからない場合はエラーを投げる", async () => {
@@ -789,11 +791,12 @@ describe("updateUserRoleWithRevocation", () => {
     const user = await updateUserRoleWithRevocation(db, "user-1", "admin");
     expect(user.role).toBe("admin");
     expect(db.batch).toHaveBeenCalledTimes(1);
-    expect(db.prepare).toHaveBeenCalledTimes(3);
+    expect(db.prepare).toHaveBeenCalledTimes(4);
     const sqls = (db.prepare as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0] as string);
     expect(sqls[0]).toContain("UPDATE users SET role");
     expect(sqls[1]).toContain("UPDATE refresh_tokens SET revoked_at");
     expect(sqls[2]).toContain("DELETE FROM mcp_sessions");
+    expect(sqls[3]).toContain("UPDATE bff_sessions SET revoked_at");
   });
 
   it("ユーザーが見つからない場合はエラーを投げる", async () => {

--- a/packages/shared/src/db/users.ts
+++ b/packages/shared/src/db/users.ts
@@ -297,6 +297,12 @@ export async function updateUserRoleWithRevocation(
       )
       .bind("security_event", userId),
     db.prepare(`DELETE FROM mcp_sessions WHERE user_id = ?`).bind(userId),
+    // BFF セッション Cookie も失効（issue #139）。role 変更時に旧セッションの role が Cookie に残るのを防ぐ。
+    db
+      .prepare(
+        `UPDATE bff_sessions SET revoked_at = ?, revoked_reason = ? WHERE user_id = ? AND revoked_at IS NULL`,
+      )
+      .bind(Math.floor(Date.now() / 1000), "security_event", userId),
   ]);
   const user = results[0]?.results?.[0] as User | undefined;
   if (!user) throw new Error("User not found");
@@ -519,6 +525,12 @@ export async function banUserWithRevocation(db: D1Database, userId: string): Pro
       )
       .bind("security_event", userId),
     db.prepare(`DELETE FROM mcp_sessions WHERE user_id = ?`).bind(userId),
+    // BFF セッション Cookie も失効（issue #139）。BAN時に Cookie が残ると access_token 有効期間中はアクセス可能になる。
+    db
+      .prepare(
+        `UPDATE bff_sessions SET revoked_at = ?, revoked_reason = ? WHERE user_id = ? AND revoked_at IS NULL`,
+      )
+      .bind(Math.floor(Date.now() / 1000), "security_event", userId),
   ]);
   const user = results[0]?.results?.[0] as User | undefined;
   if (!user) throw new Error("User not found");

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,4 +34,5 @@ export * from "./db/login-events";
 export * from "./db/admin-audit-logs";
 export * from "./db/device-codes";
 export * from "./db/mcp-sessions";
+export * from "./db/bff-sessions";
 export * from "./db/revoked-access-tokens";

--- a/packages/shared/src/lib/bff-auth-factory.ts
+++ b/packages/shared/src/lib/bff-auth-factory.ts
@@ -88,7 +88,15 @@ export function createBffAuthRoutes(config: BffAuthConfig) {
       }
     }
 
+    // IdP /auth/exchange は BFF フロー時に必ず session_id を返す仕様。
+    // 未返却は IdP 側の不整合（例: バージョン不一致）なのでセッション確立を拒否する。
+    if (!result.data.session_id) {
+      logger.error("[callback] IdP did not return session_id for BFF flow");
+      return c.redirect("/?error=exchange_failed");
+    }
+
     await setSessionCookie(c, config.sessionCookieName, {
+      session_id: result.data.session_id,
       access_token: result.data.access_token,
       refresh_token: result.data.refresh_token,
       user: result.data.user,
@@ -105,7 +113,7 @@ export function createBffAuthRoutes(config: BffAuthConfig) {
     );
     if (sessionData) {
       try {
-        await revokeTokenAtIdp(c.env, sessionData.refresh_token);
+        await revokeTokenAtIdp(c.env, sessionData.refresh_token, sessionData.session_id);
       } catch (err) {
         logger.error("[logout] IdP revoke request failed", err);
       }

--- a/packages/shared/src/lib/bff.test.ts
+++ b/packages/shared/src/lib/bff.test.ts
@@ -27,6 +27,7 @@ import { getCookie, setCookie, deleteCookie } from "hono/cookie";
 const TEST_SECRET = "test-session-secret-for-unit-tests-only-32b";
 
 const mockSession: BffSession = {
+  session_id: "00000000-0000-0000-0000-000000000000",
   access_token: "access-token-123",
   refresh_token: "refresh-token-456",
   user: { id: "user-1", email: "test@example.com", name: "Test User", role: "user" },
@@ -357,7 +358,7 @@ describe("setSessionCookie", () => {
       secure: true,
       sameSite: "Lax",
       path: "/",
-      maxAge: 30 * 24 * 60 * 60,
+      maxAge: 7 * 24 * 60 * 60,
     });
   });
 

--- a/packages/shared/src/lib/bff.ts
+++ b/packages/shared/src/lib/bff.ts
@@ -4,7 +4,18 @@ import type { BffEnv } from "../types";
 import { decodeBase64Url } from "./base64url";
 import { timingSafeEqual } from "./crypto";
 
+/**
+ * BFF セッション Cookie の最大有効期間（秒）。
+ * issue #139 対応で 30日 → 7日に短縮。Cookie 漏洩時の悪用ウィンドウを制限する。
+ */
+export const BFF_SESSION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+
 export interface BffSession {
+  /**
+   * bff_sessions テーブルの行 ID。Cookie 値に含めて送信し、BFF→IdP リクエスト毎に
+   * ID Worker 側で失効状態を検証する。Cookie 漏洩時のリモート失効を実現する。
+   */
+  session_id: string;
   access_token: string;
   refresh_token: string;
   user: { id: string; email: string; name: string; role: "user" | "admin" };
@@ -18,6 +29,7 @@ export interface BffSession {
 function isBffSession(obj: unknown): obj is BffSession {
   if (typeof obj !== "object" || obj === null || Array.isArray(obj)) return false;
   const s = obj as Record<string, unknown>;
+  if (typeof s["session_id"] !== "string" || !s["session_id"]) return false;
   if (typeof s["access_token"] !== "string" || !s["access_token"]) return false;
   if (typeof s["refresh_token"] !== "string" || !s["refresh_token"]) return false;
   if (typeof s["user"] !== "object" || s["user"] === null || Array.isArray(s["user"])) return false;
@@ -80,6 +92,7 @@ export async function parseSession(
     if (!isBffSession(raw)) return null;
     // 既知フィールドのみを抽出してプロトタイプ汚染を防止
     return {
+      session_id: raw.session_id,
       access_token: raw.access_token,
       refresh_token: raw.refresh_token,
       user: {
@@ -128,7 +141,10 @@ export async function setSessionCookie(
     secure: true,
     sameSite: "Lax",
     path: "/",
-    maxAge: 30 * 24 * 60 * 60,
+    // BFF セッション最大有効期間: 7日（従来30日から短縮）。
+    // Cookie が漏洩した場合の悪用ウィンドウを限定しつつ、日常利用での再ログインを避けるバランス。
+    // なお bff_sessions テーブルの expires_at もこの値に合わせて設定する。
+    maxAge: BFF_SESSION_MAX_AGE_SECONDS,
   });
 }
 
@@ -169,6 +185,9 @@ export async function fetchWithAuth(
 
   const serviceHeaders = internalServiceHeaders(c.env);
 
+  // BFF セッション ID を ID Worker に渡して bff_sessions の失効チェックを行わせる（issue #139）。
+  const bffSessionHeader = { "X-BFF-Session-Id": session.session_id };
+
   const makeRequest = (token: string): Promise<Response> =>
     c.env.IDP.fetch(
       new Request(url, {
@@ -176,6 +195,7 @@ export async function fetchWithAuth(
         headers: {
           ...(init?.headers as Record<string, string> | undefined),
           ...serviceHeaders,
+          ...bffSessionHeader,
           Authorization: `Bearer ${token}`,
         },
       }),
@@ -195,7 +215,11 @@ export async function fetchWithAuth(
       refreshRes = await c.env.IDP.fetch(
         new Request(`${c.env.IDP_ORIGIN}/auth/refresh`, {
           method: "POST",
-          headers: { "Content-Type": "application/json", ...serviceHeaders },
+          headers: {
+            "Content-Type": "application/json",
+            ...serviceHeaders,
+            ...bffSessionHeader,
+          },
           body: JSON.stringify({ refresh_token: session.refresh_token }),
         }),
       );
@@ -400,6 +424,8 @@ export function verifyAndConsumeOAuthState(
 export interface ExchangeResult {
   access_token: string;
   refresh_token: string;
+  /** BFF セッション ID（bff_sessions テーブルの行 ID）。BFF フロー時のみ設定される。 */
+  session_id?: string;
   user: { id: string; email: string; name: string; role: "user" | "admin" };
 }
 
@@ -428,12 +454,19 @@ export async function exchangeCodeAtIdp(
  * BFFからIdPへリフレッシュトークンの失効を要求する。
  * 通信エラーは呼び出し側で処理する。
  */
-export async function revokeTokenAtIdp(env: BffEnv, refreshToken: string): Promise<void> {
+export async function revokeTokenAtIdp(
+  env: BffEnv,
+  refreshToken: string,
+  sessionId?: string,
+): Promise<void> {
   await env.IDP.fetch(
     new Request(`${env.IDP_ORIGIN}/auth/logout`, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...internalServiceHeaders(env) },
-      body: JSON.stringify({ refresh_token: refreshToken }),
+      body: JSON.stringify({
+        refresh_token: refreshToken,
+        ...(sessionId ? { session_id: sessionId } : {}),
+      }),
     }),
   );
 }

--- a/workers/admin/src/index.test.ts
+++ b/workers/admin/src/index.test.ts
@@ -10,6 +10,7 @@ vi.mock("@0g0-id/shared", async (importOriginal) => ({
   fetchWithAuth: vi.fn(),
   proxyResponse: vi.fn(),
   parseSession: vi.fn().mockResolvedValue({
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "admin-123", email: "admin@example.com", name: "Admin", role: "admin" },
@@ -62,6 +63,7 @@ describe("onError ハンドラ", () => {
   it("未処理の例外で500とINTERNAL_ERRORを返す", async () => {
     // fetchWithAuth をスローさせて /api/metrics 経由で app.onError を通過させる
     vi.mocked(parseSession).mockResolvedValue({
+      session_id: "00000000-0000-0000-0000-000000000000",
       access_token: "mock-access-token",
       refresh_token: "mock-refresh-token",
       user: { id: "admin-123", email: "admin@example.com", name: "Admin", role: "admin" },

--- a/workers/admin/src/routes/audit-logs.test.ts
+++ b/workers/admin/src/routes/audit-logs.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://admin.0g0.xyz";
 
 async function makeSessionCookie(role: "admin" | "user" = "admin"): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "admin-user-id", email: "admin@example.com", name: "Admin", role },

--- a/workers/admin/src/routes/auth.test.ts
+++ b/workers/admin/src/routes/auth.test.ts
@@ -38,6 +38,7 @@ function makeExchangeResponse(role: "admin" | "user" = "admin") {
     data: {
       access_token: "mock-access-token",
       refresh_token: "mock-refresh-token",
+      session_id: "00000000-0000-0000-0000-000000000000",
       user: { id: "user-1", email: "admin@example.com", name: "Admin", role },
     },
   };
@@ -195,6 +196,7 @@ describe("admin BFF — /auth", () => {
 
       const sessionData = await encodeSession(
         {
+          session_id: "00000000-0000-0000-0000-000000000000",
           access_token: "mock-at",
           refresh_token: "mock-rt",
           user: { id: "user-1", email: "admin@example.com", name: "Admin", role: "admin" },

--- a/workers/admin/src/routes/metrics.test.ts
+++ b/workers/admin/src/routes/metrics.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://admin.0g0.xyz";
 
 async function makeSessionCookie(role: "admin" | "user" = "admin"): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "admin-user-id", email: "admin@example.com", name: "Admin", role },

--- a/workers/admin/src/routes/services.test.ts
+++ b/workers/admin/src/routes/services.test.ts
@@ -10,6 +10,7 @@ const baseUrl = "https://admin.0g0.xyz";
 // 管理者セッションCookieを生成するヘルパー
 async function makeSessionCookie(role: "admin" | "user" = "admin"): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "admin-user-id", email: "admin@example.com", name: "Admin", role },

--- a/workers/admin/src/routes/users.test.ts
+++ b/workers/admin/src/routes/users.test.ts
@@ -23,6 +23,7 @@ const NOT_FOUND_TOKEN_ID = "00000000-0000-0000-0000-000000000410";
 // 管理者セッションCookieを生成するヘルパー
 async function makeSessionCookie(role: "admin" | "user" = "admin"): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: ADMIN_USER_ID, email: "admin@example.com", name: "Admin", role },

--- a/workers/id/src/middleware/auth.ts
+++ b/workers/id/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import {
   findUserById,
   isAccessTokenRevoked,
   createLogger,
+  findActiveBffSession,
 } from "@0g0-id/shared";
 import type { IdpEnv, TokenPayload, User } from "@0g0-id/shared";
 
@@ -60,6 +61,24 @@ export const authMiddleware = createMiddleware<{
     if (payload.jti && (await isAccessTokenRevoked(c.env.DB, payload.jti))) {
       return c.json({ error: { code: "UNAUTHORIZED", message: "Token has been revoked" } }, 401);
     }
+
+    // BFF セッション失効チェック（issue #139）。
+    // BFF Worker が X-BFF-Session-Id ヘッダーを付与していれば、bff_sessions の有効性を確認する。
+    // 失効済みまたは未登録なら 401 を返し、BFF 側で Cookie 削除 + 再ログインを促す。
+    // 外部サービストークン（cid 付き）は BFF 由来ではないのでチェックしない。
+    if (!payload.cid) {
+      const bffSessionId = c.req.header("X-BFF-Session-Id");
+      if (bffSessionId) {
+        const session = await findActiveBffSession(c.env.DB, bffSessionId);
+        if (!session || session.user_id !== payload.sub) {
+          return c.json(
+            { error: { code: "UNAUTHORIZED", message: "Session has been revoked" } },
+            401,
+          );
+        }
+      }
+    }
+
     c.set("user", payload);
     await next();
   } catch {

--- a/workers/id/src/routes/auth.test.ts
+++ b/workers/id/src/routes/auth.test.ts
@@ -93,6 +93,12 @@ vi.mock("@0g0-id/shared", async (importOriginal) => {
     findRefreshTokenById: vi.fn(),
     // JTIブロックリスト
     addRevokedAccessToken: vi.fn(),
+    // BFFセッション（issue #139）
+    createBffSession: vi.fn(),
+    findActiveBffSession: vi.fn(),
+    revokeBffSession: vi.fn(),
+    revokeAllBffSessionsByUserId: vi.fn(),
+    BFF_SESSION_MAX_AGE_SECONDS: 7 * 24 * 60 * 60,
   };
 });
 

--- a/workers/id/src/routes/auth/exchange.ts
+++ b/workers/id/src/routes/auth/exchange.ts
@@ -11,6 +11,8 @@ import {
   generatePairwiseSub,
   signIdToken,
   createLogger,
+  createBffSession,
+  BFF_SESSION_MAX_AGE_SECONDS,
 } from "@0g0-id/shared";
 import { authenticateService } from "../../utils/service-auth";
 import { resolveEffectiveScope } from "../../utils/scopes";
@@ -147,11 +149,34 @@ export async function handleExchange(c: Context<{ Bindings: IdpEnv; Variables: V
     );
   }
 
+  // BFF フロー（service_id なし）の場合は bff_sessions に行を作成して session_id を返す。
+  // Cookie 漏洩時のリモート失効（issue #139）用。
+  let bffSessionId: string | undefined;
+  if (serviceId === null) {
+    try {
+      bffSessionId = crypto.randomUUID();
+      const now = Math.floor(Date.now() / 1000);
+      const bffOrigin = new URL(body.redirect_to).origin;
+      await createBffSession(c.env.DB, {
+        id: bffSessionId,
+        userId: user.id,
+        expiresAt: now + BFF_SESSION_MAX_AGE_SECONDS,
+        bffOrigin,
+        userAgent: c.req.header("User-Agent") ?? null,
+        ip: c.req.header("CF-Connecting-IP") ?? null,
+      });
+    } catch (err) {
+      authLogger.error("[exchange] Failed to create bff_session", err);
+      return c.json({ error: { code: "INTERNAL_ERROR", message: "Internal server error" } }, 500);
+    }
+  }
+
   return c.json({
     data: {
       access_token: accessToken,
       ...(idToken ? { id_token: idToken } : {}),
       refresh_token: refreshTokenRaw,
+      ...(bffSessionId ? { session_id: bffSessionId } : {}),
       token_type: "Bearer",
       expires_in: ACCESS_TOKEN_TTL_SECONDS,
       user: {

--- a/workers/id/src/routes/auth/logout.ts
+++ b/workers/id/src/routes/auth/logout.ts
@@ -10,12 +10,14 @@ import {
   addRevokedAccessToken,
   createLogger,
   restErrorBody,
+  revokeBffSession,
 } from "@0g0-id/shared";
 
 const authLogger = createLogger("auth");
 
 const LogoutSchema = z.object({
   refresh_token: z.string().optional(),
+  session_id: z.string().uuid().optional(),
 });
 
 type Variables = { user: TokenPayload };
@@ -46,7 +48,20 @@ export async function handleLogout(c: Context<{ Bindings: IdpEnv; Variables: Var
     }
   }
 
-  const { refresh_token: refreshToken } = result.data;
+  const { refresh_token: refreshToken, session_id: bffSessionId } = result.data;
+
+  // BFF セッションの失効（issue #139 対応）。
+  // refresh_token 失効と独立して行うことで、Cookie 側 session_id だけでも確実に失効させる。
+  if (bffSessionId) {
+    try {
+      await revokeBffSession(c.env.DB, bffSessionId, "user_logout");
+    } catch (err) {
+      authLogger.error("[logout] Failed to revoke bff_session", err);
+      // bff_session 失効失敗はログアウト全体を失敗扱いにする（Cookie が活きたままになるのを避ける）
+      return c.json(restErrorBody("INTERNAL_ERROR", "Failed to revoke session"), 500);
+    }
+  }
+
   if (refreshToken) {
     const tokenHash = await sha256(refreshToken);
     let storedToken: RefreshToken | null;

--- a/workers/id/src/routes/openapi/internal-spec.ts
+++ b/workers/id/src/routes/openapi/internal-spec.ts
@@ -79,6 +79,11 @@ export const INTERNAL_OPENAPI = {
         properties: {
           access_token: { type: "string" },
           refresh_token: { type: "string" },
+          session_id: {
+            type: "string",
+            format: "uuid",
+            description: "BFFセッションID（BFFフロー時のみ返却。リモート失効用）",
+          },
           token_type: { type: "string", example: "Bearer" },
           expires_in: { type: "integer", example: 900 },
           user: { $ref: "#/components/schemas/User" },
@@ -129,7 +134,7 @@ export const INTERNAL_OPENAPI = {
         tags: ["認証フロー"],
         summary: "コードをトークンに交換",
         description:
-          "ワンタイムコードをアクセストークン（15分）＋リフレッシュトークン（30日）に交換する。Service Bindingsによるサーバー間通信専用。",
+          "ワンタイムコードをアクセストークン（15分）＋リフレッシュトークン（30日）に交換する。Service Bindingsによるサーバー間通信専用。BFFフロー時は session_id（bff_sessions 行ID）を同梱し、Cookie に埋め込むことでリモート失効可能にする。",
         requestBody: {
           required: true,
           content: {
@@ -201,7 +206,8 @@ export const INTERNAL_OPENAPI = {
       post: {
         tags: ["認証フロー"],
         summary: "ログアウト",
-        description: "リフレッシュトークンファミリー全体を失効させる。",
+        description:
+          "リフレッシュトークンファミリー全体を失効させる。session_id が指定された場合は bff_sessions の該当行も失効させる。",
         requestBody: {
           content: {
             "application/json": {
@@ -211,6 +217,12 @@ export const INTERNAL_OPENAPI = {
                   refresh_token: {
                     type: "string",
                     description: "失効させるトークン（省略時は何もしない）",
+                  },
+                  session_id: {
+                    type: "string",
+                    format: "uuid",
+                    description:
+                      "BFFセッションID。Cookie に埋め込まれている session_id を渡すことで bff_sessions 側も失効させる。",
                   },
                 },
               },

--- a/workers/id/src/routes/users.test.ts
+++ b/workers/id/src/routes/users.test.ts
@@ -20,6 +20,8 @@ vi.mock("@0g0-id/shared", async (importOriginal) => {
     revokeUserServiceTokens: vi.fn(),
     revokeUserTokens: vi.fn(),
     deleteMcpSessionsByUser: vi.fn(),
+    revokeAllBffSessionsByUserId: vi.fn(),
+    findActiveBffSession: vi.fn(),
     revokeTokenByIdForUser: vi.fn(),
     revokeOtherUserTokens: vi.fn(),
     listActiveSessionsByUserId: vi.fn(),

--- a/workers/id/src/routes/users.ts
+++ b/workers/id/src/routes/users.ts
@@ -11,6 +11,7 @@ import {
   revokeUserServiceTokens,
   revokeUserTokens,
   deleteMcpSessionsByUser,
+  revokeAllBffSessionsByUserId,
   revokeTokenByIdForUser,
   revokeOtherUserTokens,
   listActiveSessionsByUserId,
@@ -526,6 +527,10 @@ app.delete(
     const tokenUser = c.get("user");
     await revokeUserTokens(c.env.DB, tokenUser.sub, "user_logout_all");
     await deleteMcpSessionsByUser(c.env.DB, tokenUser.sub);
+    // BFF セッション Cookie もリモート失効（issue #139）。
+    // refresh_token 失効だけでは Cookie 内 access_token（15分）が残るため、
+    // bff_sessions 側でも確実に無効化する。
+    await revokeAllBffSessionsByUserId(c.env.DB, tokenUser.sub, "user_logout_all");
     return c.body(null, 204);
   },
 );

--- a/workers/user/src/routes/auth.test.ts
+++ b/workers/user/src/routes/auth.test.ts
@@ -27,6 +27,7 @@ function buildApp(idpFetch: (req: Request) => Promise<Response>) {
 
 async function makeSessionCookie(userId = "user-123"): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: userId, email: "user@example.com", name: "Test User", role: "user" as const },
@@ -144,6 +145,7 @@ describe("user BFF — /auth", () => {
         data: {
           access_token: "new-access-token",
           refresh_token: "new-refresh-token",
+          session_id: "00000000-0000-0000-0000-000000000000",
           user: { id: "user-123", email: "user@example.com", name: "Test User", role: "user" },
         },
       };
@@ -171,6 +173,7 @@ describe("user BFF — /auth", () => {
         data: {
           access_token: "token",
           refresh_token: "refresh",
+          session_id: "00000000-0000-0000-0000-000000000000",
           user: { id: "u1", email: "e@e.com", name: "N", role: "user" },
         },
       };

--- a/workers/user/src/routes/connections.test.ts
+++ b/workers/user/src/routes/connections.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://user.0g0.xyz";
 
 async function makeSessionCookie(): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "user-123", email: "user@example.com", name: "Test User", role: "user" as const },

--- a/workers/user/src/routes/device.test.ts
+++ b/workers/user/src/routes/device.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://user.0g0.xyz";
 
 async function makeSessionCookie(userId = "user-123"): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: userId, email: "user@example.com", name: "Test User", role: "user" as const },

--- a/workers/user/src/routes/login-history.test.ts
+++ b/workers/user/src/routes/login-history.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://user.0g0.xyz";
 
 async function makeSessionCookie(): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "user-123", email: "user@example.com", name: "Test User", role: "user" as const },

--- a/workers/user/src/routes/profile.test.ts
+++ b/workers/user/src/routes/profile.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://user.0g0.xyz";
 
 async function makeSessionCookie(): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "user-123", email: "user@example.com", name: "Test User", role: "user" as const },

--- a/workers/user/src/routes/providers.test.ts
+++ b/workers/user/src/routes/providers.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://user.0g0.xyz";
 
 async function makeSessionCookie(): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "user-123", email: "user@example.com", name: "Test User", role: "user" as const },

--- a/workers/user/src/routes/security.test.ts
+++ b/workers/user/src/routes/security.test.ts
@@ -9,6 +9,7 @@ const baseUrl = "https://user.0g0.xyz";
 
 async function makeSessionCookie(): Promise<string> {
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: "mock-refresh-token",
     user: { id: "user-123", email: "user@example.com", name: "Test User", role: "user" as const },

--- a/workers/user/src/routes/sessions.test.ts
+++ b/workers/user/src/routes/sessions.test.ts
@@ -10,6 +10,7 @@ const baseUrl = "https://user.0g0.xyz";
 async function makeSessionCookie(opts: { refreshToken?: string } = {}): Promise<string> {
   const { refreshToken = "mock-refresh-token" } = opts;
   const session = {
+    session_id: "00000000-0000-0000-0000-000000000000",
     access_token: "mock-access-token",
     refresh_token: refreshToken,
     user: { id: "user-123", email: "user@example.com", name: "Test User", role: "user" as const },


### PR DESCRIPTION
## Summary

- Cookie 漏洩時にリモートで強制失効できなかった BFF セッションを D1 永続化（`bff_sessions`）
- `BffSession` Cookie に `session_id` を格納し、`fetchWithAuth` が `X-BFF-Session-Id` として ID Worker に送付
- `authMiddleware` が `bff_sessions` の `revoked_at` / `expires_at` をチェックし、失効なら 401
- Cookie maxAge 30日→7日に短縮（新定数 `BFF_SESSION_MAX_AGE_SECONDS`）
- logout / DELETE /me/tokens / ban / role変更時に `bff_sessions` も batch 失効

## 関連Issue

Closes #139

## Test plan

- [x] `npx vp check` — lint + format + typecheck 全通過
- [x] `npx vp test run` — 2391 テスト全通過（新規 9 テスト含む）
- [x] マイグレーション `0023_bff_sessions.sql` を本番 D1 に適用済
- [ ] デプロイ後、ログイン → 管理画面から別デバイスサインアウト → 対象端末で 401 になることを手動確認
- [ ] Cookie 暗号化鍵ローテーション設計は別 issue としてフォローアップ

## 未対応（issue #139 対策方針より）

4. 鍵ローテーション設計 → 別 issue で対応予定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced server-side session revocation support for enhanced security and remote session management.
  * Sessions now include server-side tracking with creation, expiration, and revocation metadata.

* **Bug Fixes**
  * Logout operations now comprehensively revoke all active sessions across devices.
  * Role changes and account bans now automatically invalidate all user sessions.
  * Session validation strengthened on each request.

* **Changes**
  * Session cookie lifetime reduced from 30 days to 7 days for improved security.
  * Stale sessions are periodically cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->