### PR TITLE
コードレビュー: apiFetch に 503 TOKEN_ROTATED 自動リトライ (#148)

### DIFF
--- a/workers/admin/frontend/src/lib/api.ts
+++ b/workers/admin/frontend/src/lib/api.ts
@@ -1,5 +1,17 @@
-export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(path, {
+type ApiError = { error: { code: string; message: string } };
+
+function isTokenRotatedBody(body: unknown): body is ApiError {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "error" in body &&
+    typeof (body as { error?: unknown }).error === "object" &&
+    (body as ApiError).error?.code === "TOKEN_ROTATED"
+  );
+}
+
+async function doFetch(path: string, options?: RequestInit): Promise<Response> {
+  return fetch(path, {
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json",
@@ -7,6 +19,24 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
     },
     ...options,
   });
+}
+
+export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
+  let res = await doFetch(path, options);
+
+  // 503 TOKEN_ROTATED: 並行リクエスト競合で BFF がローテーション中。
+  // セッションは有効なので短い遅延後に 1 度だけ自動リトライする。
+  if (res.status === 503) {
+    const peek = await res
+      .clone()
+      .json()
+      .catch(() => null);
+    if (isTokenRotatedBody(peek)) {
+      await new Promise((r) => setTimeout(r, 400));
+      res = await doFetch(path, options);
+    }
+  }
+
   if (res.status === 401) {
     window.location.href = "/";
     throw new Error("Unauthorized");

--- a/workers/user/frontend/src/lib/api.ts
+++ b/workers/user/frontend/src/lib/api.ts
@@ -1,8 +1,17 @@
-export async function apiFetch<T>(
-  path: string,
-  options?: RequestInit,
-): Promise<T | { error: { code: string; message: string } }> {
-  const res = await fetch(path, {
+type ApiError = { error: { code: string; message: string } };
+
+function isTokenRotatedBody(body: unknown): body is ApiError {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "error" in body &&
+    typeof (body as { error?: unknown }).error === "object" &&
+    (body as ApiError).error?.code === "TOKEN_ROTATED"
+  );
+}
+
+async function doFetch(path: string, options?: RequestInit): Promise<Response> {
+  return fetch(path, {
     credentials: "same-origin",
     headers: {
       "Content-Type": "application/json",
@@ -10,6 +19,27 @@ export async function apiFetch<T>(
     },
     ...options,
   });
+}
+
+export async function apiFetch<T>(
+  path: string,
+  options?: RequestInit,
+): Promise<T | { error: { code: string; message: string } }> {
+  let res = await doFetch(path, options);
+
+  // 503 TOKEN_ROTATED: 並行リクエスト競合で BFF がローテーション中。
+  // セッションは有効なので短い遅延後に 1 度だけ自動リトライする。
+  if (res.status === 503) {
+    const peek = await res
+      .clone()
+      .json()
+      .catch(() => null);
+    if (isTokenRotatedBody(peek)) {
+      await new Promise((r) => setTimeout(r, 400));
+      res = await doFetch(path, options);
+    }
+  }
+
   if (res.status === 401) {
     window.location.href = "/";
     throw new Error("Unauthorized");


### PR DESCRIPTION
Closes #148

## Summary

- BFF はトークンローテーション並行競合時に `503 { error: { code: "TOKEN_ROTATED" } }` を返す（セッションは有効）
- 従来のフロントエンド `apiFetch` は 503 を一般 HTTP エラー扱いしており、ユーザーは手動リロードを強いられていた
- user/admin 両方の `apiFetch` に 503 TOKEN_ROTATED 検出 + 400ms 遅延 + 1 回自動リトライを追加

## 変更点

- `workers/user/frontend/src/lib/api.ts`
- `workers/admin/frontend/src/lib/api.ts`

いずれも `res.clone().json()` で中身を peek し、`code === "TOKEN_ROTATED"` のときだけリトライ。リトライ後の結果は通常フローに落ちるので無限リトライにはならない。

## Test plan

- [x] `npx vp check` — format / lint / typecheck 全 pass
- [x] `npx vp test run` — 94 files / 2409 tests 全 pass
- [x] `npm run build`（user frontend / admin frontend 両方）成功